### PR TITLE
Missing "addRoomNameToDeviceName" in schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -73,7 +73,23 @@
           }
         ],
         "default": "disabled"
-      }
+      },
+      "addRoomNameToDeviceName": {
+        "description": "Enable or disable adding the Room name to the device name.",
+        "title": "Add room name to devices",
+        "type": "string",
+        "oneOf": [
+          {
+            "title": "Enabled",
+            "enum": ["enabled"]
+          },
+          {
+            "title": "Disabled",
+            "enum": ["disabled"]
+          }
+        ],
+        "default": "disabled"
+      }      
     }
   },
   "form": null,


### PR DESCRIPTION
Hello. This PR is for fixing the missing "addRoomNameToDeviceName" in homebridge schema.