### PR TITLE
Outlets and Switches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "homebridge Fibaro Home Center",
   "name": "homebridge-fibaro-home-center",
-  "version": "1.2.20",
+  "version": "1.4.0",
   "description": "Homebridge plugin for Fibaro Home Center 3 ",
   "author": "ilcato",
   "license": "Apache-2.0",

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -65,6 +65,11 @@ export class FibaroAccessory {
       case 'com.fibaro.developer.bxs.virtualBinarySwitch':
       case 'com.fibaro.satelOutput':
       case 'com.fibaro.FGWDS221':
+      case 'com.fibaro.FGWP101':
+      case 'com.fibaro.FGWP102':
+      case 'com.fibaro.FGWPG111':
+      case 'com.fibaro.FGWPG121':
+      case 'com.fibaro.FGWOEF011':
         switch (controlType) {
           case 2: // Lighting
           case 5: // Bedside Lamp
@@ -72,9 +77,10 @@ export class FibaroAccessory {
             service = this.platform.Service.Lightbulb;
             this.mainCharacteristics = [this.platform.Characteristic.On];
             break;
-          case 20: // Wall Socket
-            service = this.platform.Service.Outlet;
-            this.mainCharacteristics = [this.platform.Characteristic.On, this.platform.Characteristic.OutletInUse];
+          case 1: // Other device
+          case 20: // Other device
+            service = this.platform.Service.Switch;
+            this.mainCharacteristics = [this.platform.Characteristic.On];
             break;
           case 25: // Video gate open
             service = this.platform.Service.LockMechanism;
@@ -90,8 +96,8 @@ export class FibaroAccessory {
             ];
             break;
           default:
-            service = this.platform.Service.Switch;
-            this.mainCharacteristics = [this.platform.Characteristic.On];
+            service = this.platform.Service.Outlet;
+            this.mainCharacteristics = [this.platform.Characteristic.On, this.platform.Characteristic.OutletInUse];
             break;
         }
         break;
@@ -208,14 +214,6 @@ export class FibaroAccessory {
             this.isValid = false;
             return;
         }
-        break;
-      case 'com.fibaro.FGWP101':
-      case 'com.fibaro.FGWP102':
-      case 'com.fibaro.FGWPG111':
-      case 'com.fibaro.FGWPG121':
-      case 'com.fibaro.FGWOEF011':
-        service = this.platform.Service.Outlet;
-        this.mainCharacteristics = [this.platform.Characteristic.On, this.platform.Characteristic.OutletInUse];
         break;
       case 'com.fibaro.doorLock':
       case 'com.fibaro.gerda':

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -82,6 +82,7 @@ export class FibaroAccessory {
             service = this.platform.Service.Switch;
             this.mainCharacteristics = [this.platform.Characteristic.On];
             break;
+          case 24: // Video intercom
           case 25: // Video gate open
             service = this.platform.Service.LockMechanism;
             subtype = device.id + '--' + 'LOCK';

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -87,6 +87,7 @@ export class FibaroAccessory {
             subtype = device.id + '--' + 'LOCK';
             this.mainCharacteristics = [this.platform.Characteristic.LockCurrentState, this.platform.Characteristic.LockTargetState];
             break;
+          case 3: // sprinkler
           case 26: // valve
             service = this.platform.Service.Valve;
             this.mainCharacteristics = [


### PR DESCRIPTION
- Currently, if we have a Wall Plug (etc.), no matter what option we choose in the Role field (in HCL 2 the field is called What controls the device), it will still be Outlet. I think that the Wall Plug can control the lamp, sprinkler, etc., just as well. I propose to combine this group: Wall Plug, Binary Switch, etc. into one.
- Currently in the group where com.fibaro.binarySwitch is we have control type case 20 - in HCL 2 this is "other device" (no wall plug - there is no option wall plug to choose). In HCL 3 "other device" is case 1. I suggest that case 1 and 20 ("other device") mean Switch. And by default should be Outlet.
- I also added case 3 (sprinkler) to be displayed as Valve
- I also added case 24 (Video intercom) to be displayed as Lock Mechanism