### PR TITLE
Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@ For devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can ch
 + selecting Sprinkler or Valve should set device as Valve,
 + and any other case will be Outlet.
 
-To see the effect after changing, you must remove this device from cache in Homebridge Settings.
+To see the effect after changing, you must remove this device from cache in Homebridge Settings. Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).
 
 # Troubleshooting
 + If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).
-+ If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).
 
 # Latest release notes
 Version 1.4.1

--- a/README.md
+++ b/README.md
@@ -50,4 +50,6 @@ To see the effect after changing, you must remove this device from cache in Home
 # Last release notes
 Version 1.4.1
 + Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
-+ If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
+
+#### IMPORTANT!
+If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can ch
 To see the effect after changing, you must remove this device from cache in Homebridge Settings.
 
 # Troubleshooting
-+ If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
++ If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
 + If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).
 
 # Latest release notes
@@ -52,4 +52,4 @@ Version 1.4.1
 + Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
 
 #### IMPORTANT!
-If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
+If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Look for a sample config in [config.json example](https://github.com/ilcato/home
 + Use different device names within the same room in Home Center.
 
 # Troubleshooting
-+ If device displays incorrectly (e.g. as Switch but should be Outlet) or double, you must remove this device from cache (in Homebridge Settings).
++ If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
++ If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).
 
 # Last release notes
 Version 1.4.0

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Look for a sample config in [config.json example](https://github.com/ilcato/home
 + Use different device names within the same room in Home Center.
 
 # Troubleshooting
-+ The device displays incorrectly (e.g. as Switch and should be Outlet) or double. Sometimes this happens, especially after changing the type of display (e.g. from Switch to Outlet). You must remove this device from cache in Homebridge Settings.
++ If device displays incorrectly (e.g. as Switch but should be Outlet) or double, you must remove this device from cache (in Homebridge Settings).
 
 # Last release notes
 Version 1.4.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To see the effect after changing, you must remove this device from cache in Home
 + If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
 + If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).
 
-# Last release notes
+# Latest release notes
 Version 1.4.1
 + Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
 

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ To see the effect after changing, you must remove this device from cache in Home
 Version 1.4.1
 + Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
 
-#### IMPORTANT!
-If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).
+#### WARNING !
+This can make some devices display twice. If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Look for a sample config in [config.json example](https://github.com/ilcato/home
 # Warning
 + Use different device names within the same room in Home Center.
 
+# Changing the display type of the device
+For devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device).
++ Selecting Light should set device as Light,
++ selecting "Other" / "Another device" should set the device as Switch,
++ selecting Sprinkler or Valve should set device as Valve,
++ and any other case will be Outlet.
+
+To see the effect after changing, you must remove this device from cache in Homebridge Settings.
+
 # Troubleshooting
 + If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
 + If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can ch
 To see the effect after changing, you must remove this device from cache in Homebridge Settings.
 
 # Troubleshooting
-+ If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
++ If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).
 + If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).
 
 # Latest release notes
@@ -52,4 +52,4 @@ Version 1.4.1
 + Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
 
 #### IMPORTANT!
-If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).
+If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ To see the effect after changing, you must remove this device from cache in Home
 + If your device is not supported or displays incorrectly despite removing it from the cache - [see here](https://github.com/ilcato/homebridge-fibaro-home-center/issues/157).
 
 # Last release notes
-Version 1.4.0
-+ Log management improved - Thanks to @mkz212
-+ Wallplug and outlet management improved - Thanks to @mkz212
+Version 1.4.1
++ Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
++ If device displays incorrectly (e.g. as Switch but should be Outlet) or double (one device is displayed as two), you must remove this device from cache (in Homebridge Settings).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Look for a sample config in [config.json example](https://github.com/ilcato/home
 # Warning
 + Use different device names within the same room in Home Center.
 
+# Troubleshooting
++ The device displays incorrectly (e.g. as Switch and should be Outlet) or double. Sometimes this happens, especially after changing the type of display (e.g. from Switch to Outlet). You must remove this device from cache in Homebridge Settings.
+
 # Last release notes
 Version 1.4.0
 + Log management improved - Thanks to @mkz212

--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ Version 1.4.1
 + Now for devices like Switch, Double Switch, Smart Implant, Wall Plug etc. you can change how it will display in Homekit - in the Fibaro panel go to this device and check field Role (or What controls the device). Selecting Light should set device as Light, selecting "Other" / "Another device" should set the device as Switch, selecting Sprinkler or Valve should set device as Valve, and any other case will be Outlet.
 
 #### WARNING !
-This can make some devices display twice. If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).
+This can make some devices display doubled. If device displays incorrectly (e.g. as Switch but should be Outlet) or doubled (one device is displayed as two), you must remove this device from cache (in Homebridge Settings). Unfortunately, in this case, the settings for this device will most likely be lost (room selection, automations, etc.).


### PR DESCRIPTION
@ilcato Please also add to the changelog of the next release information that if the device is displayed incorrectly or double, it should be removed from the cache first (Homebridge settings).

P.S.: When do you plan to release the next version?