### PR TITLE
New workflow: stale (auto close old Issues)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# Close stale issues after a defined period of time.
+#
+name: Close Stale Issues
+
+on:
+  issues:
+    types: [reopened]
+  schedule:
+  - cron: "30 4 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Autoclose stale issues.
+      uses: actions/stale@v8
+      with:
+        days-before-close: 7
+        days-before-stale: 21
+        exempt-issue-labels: 'do-not-remove,in-progress'
+        exempt-pr-labels: 'do-not-remove,in-progress'
+        remove-stale-when-updated: true
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'stale'
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs. Thank you for your contributions.'
+        stale-pr-label: 'stale'
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity. It will be closed in 7 days if no further activity occurs. Thank you for your contributions.'


### PR DESCRIPTION
Such a workflow could be added to close the old Issues. This will help keep the reports in order, automatically remove obsolete bug reports. I suggest that after 3 weeks of inactivity send a message and give another 7 days and when there is no activity then close Issue. Cron job runs everyday on 4:30 am.