### PR TITLE
Fix some old warnings (lint compile)

### DIFF
--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -75,7 +75,7 @@ export class FibaroAccessory {
             this.platform.Characteristic.Saturation];
         break;
       // Light / Switch / Outlet / Valve
-      // for Switch / Double Switch / Smart Implant / etc. 
+      // for Switch / Double Switch / Smart Implant / etc.
       case 'com.fibaro.binarySwitch':
       case 'com.fibaro.developer.bxs.virtualBinarySwitch':
       case 'com.fibaro.satelOutput':
@@ -147,7 +147,7 @@ export class FibaroAccessory {
           break;
         }
       // Light / Switch / Outlet / Valve
-      // for Wall Plug etc. 
+      // for Wall Plug etc.
       case 'com.fibaro.FGWP101':
       case 'com.fibaro.FGWP102':
       case 'com.fibaro.FGWPG111':

--- a/src/getFunctions.ts
+++ b/src/getFunctions.ts
@@ -195,7 +195,7 @@ export class GetFunctions {
         characteristic.updateValue(properties.currentTemperature);
       } catch (e) {
         this.platform.log('Error getting Current Temperature Heating Zone: ', `${service.IDs[0]} - Err: ${e}`);
-        return
+        return;
       }
     } else {
       const value = properties.value;
@@ -226,7 +226,7 @@ export class GetFunctions {
         characteristic.updateValue(properties.currentTemperature);
       } catch (e) {
         this.platform.log('Error getting Target Temperature Heating Zone: ', `${service.IDs[0]} - Err: ${e}`);
-        return
+        return;
       }
     } else {
       const value = properties.value;


### PR DESCRIPTION
There are still some old warning. You can fix them in your free time. Currently, the number of warnings does not exceed the limit so it is nothing urgent.