### PR TITLE
Filter out devices with the same name in the same room

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ See: [security system](https://github.com/ilcato/homebridge-Fibaro-home-center/b
 
 ### Version 1.5.2
 + Now you can enter Home Center / Yubii Home IP directly in "url" field in config. Field "host" is deprecated and will be removed in the future.
++ Filter out devices with the same name in the same room.
 
 ### Version 1.5.1
 + Fix bug causing endless rastarting Homebridge when unable to connect to Home Center / Yubii Home

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -216,7 +216,7 @@ export class FibaroHC implements DynamicPlatformPlugin {
     // Add room name to device name if addRoomNameToDeviceName = enabled
     this.log.info('Loading accessories');
     const filteredDevices: { name: string; roomID: string }[] = [];
-    devices.map((s: { name: string; roomID: string }) => {
+    devices.map((s) => {
       if (s.visible === true && !s.name.startsWith('_')) {
         const f = filteredDevices.find((d) => d.name === s.name && d.roomID === s.roomID);
         if (f === undefined) {


### PR DESCRIPTION
To avoid runtime errors calling event callback multiple times.