### PR TITLE
Update setFunctions.ts - fix dimmers and roller shutters

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ If you have any issues with this plugin, enable all logs in plugin config and th
 # Latest release notes
 
 ### Version 1.6.1
-+ Upgraded to homebridge 1.7
++ Fix dimmers (blinking) and roller shutters.
++ Upgraded to homebridge 1.7.
++ Upgraded dependencies.
 
 ### Version 1.6.0
 + Added the ability to have devices with the same name in the same room (in Fibaro configuration). This applies to newly added devices or devices with updated name or room. For existing devices, changing the name of the device or assigning it to another room will give a new uuid and thus it may break the automation in HomeKit (as before), but it will also cause the transition to a new internal mechanism that will not suffer for such a problems in the future. The update itself will not change anything - it will not break devices or automations.

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -89,7 +89,7 @@ export class SetFunctions {
       }
       this.setGlobalVariable(IDs[1], value === true ? '100' : '0');
     } else {
-      if (!service.isUpdating){
+      if (!service.isUpdating) { // see in setBrightness function
         await this.command(value ? 'turnOn' : 'turnOff', null, service, IDs);
       }
     }
@@ -99,20 +99,21 @@ export class SetFunctions {
     if (service.isGlobalVariableDimmer) {
       await this.setGlobalVariable(IDs[1], value.toString());
     } else {
+      // if this is first command
       if (!service.isUpdating) {
-        service.isUpdating = true;
+        // block other updates in this time
+        service.isUpdating = true; 
         await this.command('setValue', [value], service, IDs);
-        this.platform.log('setValue ' + value);
-
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
           service.isUpdating = false;
         }, 300);
+        // every command will extend timer
+        // execute only last command
       } else {
         clearTimeout(this.timeout);
         this.timeout = setTimeout(async () => {
           await this.command('setValue', [value], service, IDs);
-          this.platform.log('setValue ' + value);
           service.isUpdating = false;
         }, 300);
       }

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -102,7 +102,7 @@ export class SetFunctions {
       // if this is first command
       if (!service.isUpdating) {
         // block other updates in this time
-        service.isUpdating = true; 
+        service.isUpdating = true;
         await this.command('setValue', [value], service, IDs);
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -121,7 +121,7 @@ export class SetFunctions {
       this.timeouts[IDs] = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
         service.isUpdating = false;
-      }, 500);
+      }, 1500);
     }
   }
 

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -26,6 +26,7 @@ export class SetFunctions {
 
   constructor(platform) {
     this.platform = platform;
+    this.timeout = null;
 
     const setCharacteristicFunctions = {
       On: this.setOn,

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -99,24 +99,12 @@ export class SetFunctions {
     if (service.isGlobalVariableDimmer) {
       await this.setGlobalVariable(IDs[1], value.toString());
     } else {
-      // if this is first command
-      if (!service.isUpdating) {
-        // block other updates in this time
-        service.isUpdating = true;
+      service.isUpdating = true;
+      clearTimeout(this.timeout);
+      this.timeout = setTimeout(() => {
         await this.command('setValue', [value], service, IDs);
-        clearTimeout(this.timeout);
-        this.timeout = setTimeout(() => {
-          service.isUpdating = false;
-        }, 200);
-        // every command will extend timer
-        // execute only last command
-      } else {
-        clearTimeout(this.timeout);
-        this.timeout = setTimeout(async () => {
-          await this.command('setValue', [value], service, IDs);
-          service.isUpdating = false;
-        }, 200);
-      }
+        service.isUpdating = false;
+      }, 200);  
     }
   }
 
@@ -128,9 +116,11 @@ export class SetFunctions {
         await this.command('open', [0], service, IDs);
       }
     } else {
+      service.isUpdating = true;
       clearTimeout(this.timeout);
       this.timeout = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
+        service.isUpdating = false;
       }, 200);
     }
   }

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -104,7 +104,7 @@ export class SetFunctions {
       this.timeout = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
         service.isUpdating = false;
-      }, 200);
+      }, 500);
     }
   }
 
@@ -121,7 +121,7 @@ export class SetFunctions {
       this.timeout = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
         service.isUpdating = false;
-      }, 200);
+      }, 500);
     }
   }
 

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -23,6 +23,7 @@ export class SetFunctions {
   setFunctionsMapping;
   getTargetSecuritySystemSceneMapping;
   platform;
+  timeout;
 
   constructor(platform) {
     this.platform = platform;

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -89,7 +89,7 @@ export class SetFunctions {
       }
       this.setGlobalVariable(IDs[1], value === true ? '100' : '0');
     } else {
-      if (!service.isUpdating) { // see in setBrightness function
+      if (!this.timeouts[IDs]) { // see in setBrightness function
         await this.command(value ? 'turnOn' : 'turnOff', null, service, IDs);
       }
     }
@@ -99,11 +99,9 @@ export class SetFunctions {
     if (service.isGlobalVariableDimmer) {
       await this.setGlobalVariable(IDs[1], value.toString());
     } else {
-      service.isUpdating = true;
       clearTimeout(this.timeouts[IDs]);
       this.timeouts[IDs] = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
-        service.isUpdating = false;
       }, 500);
     }
   }
@@ -116,11 +114,9 @@ export class SetFunctions {
         await this.command('open', [0], service, IDs);
       }
     } else {
-      service.isUpdating = true;
       clearTimeout(this.timeouts[IDs]);
       this.timeouts[IDs] = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
-        service.isUpdating = false;
       }, 1500);
     }
   }

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -102,7 +102,7 @@ export class SetFunctions {
         service.isUpdating = true;
         await this.command('setValue', [value], service, IDs);
         this.platform.log('setValue ' + value);
-                
+
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
           service.isUpdating = false;

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -101,10 +101,10 @@ export class SetFunctions {
     } else {
       service.isUpdating = true;
       clearTimeout(this.timeout);
-      this.timeout = setTimeout(() => {
+      this.timeout = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
         service.isUpdating = false;
-      }, 200);  
+      }, 200);
     }
   }
 

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -107,7 +107,7 @@ export class SetFunctions {
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
           service.isUpdating = false;
-        }, 300);
+        }, 200);
         // every command will extend timer
         // execute only last command
       } else {
@@ -115,7 +115,7 @@ export class SetFunctions {
         this.timeout = setTimeout(async () => {
           await this.command('setValue', [value], service, IDs);
           service.isUpdating = false;
-        }, 300);
+        }, 200);
       }
     }
   }
@@ -128,7 +128,10 @@ export class SetFunctions {
         await this.command('open', [0], service, IDs);
       }
     } else {
-      await this.command('setValue', [value], service, IDs);
+      clearTimeout(this.timeout);
+      this.timeout = setTimeout(async () => {
+        await this.command('setValue', [value], service, IDs);
+      }, 200);
     }
   }
 

--- a/src/setFunctions.ts
+++ b/src/setFunctions.ts
@@ -23,11 +23,11 @@ export class SetFunctions {
   setFunctionsMapping;
   getTargetSecuritySystemSceneMapping;
   platform;
-  timeout;
+  timeouts;
 
   constructor(platform) {
     this.platform = platform;
-    this.timeout = null;
+    this.timeouts = {};
 
     const setCharacteristicFunctions = {
       On: this.setOn,
@@ -100,8 +100,8 @@ export class SetFunctions {
       await this.setGlobalVariable(IDs[1], value.toString());
     } else {
       service.isUpdating = true;
-      clearTimeout(this.timeout);
-      this.timeout = setTimeout(async () => {
+      clearTimeout(this.timeouts[IDs]);
+      this.timeouts[IDs] = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
         service.isUpdating = false;
       }, 500);
@@ -117,8 +117,8 @@ export class SetFunctions {
       }
     } else {
       service.isUpdating = true;
-      clearTimeout(this.timeout);
-      this.timeout = setTimeout(async () => {
+      clearTimeout(this.timeouts[IDs]);
+      this.timeouts[IDs] = setTimeout(async () => {
         await this.command('setValue', [value], service, IDs);
         service.isUpdating = false;
       }, 500);


### PR DESCRIPTION
When you click in Apple Home on dimmer icon - you turn on or off. When you go to detailed view (this with slider) you have to options: when you click somewhere on slider you set value, but when you click and move up or down the application sends a lot of commands - it does not send one command when you finish moving and raising your finger.

To solve this, I enter a timer. If it is a series of commands, each command clear previous timer , so time is extended, and only one last command is executed.

I also fix Roller Shutters like this. 

This PR should also solve the problem of sending 2 commands by Siri #237 