### PR TITLE
support for more devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ If you have any issues with this plugin, enable all logs in plugin config and th
 
 # Latest release notes
 
+### Version 1.8.0
++ Support for many new devices, also the upcoming ones
++ Bump dependencies
+
 ### Version 1.7.5
 + Added new Fibaro "Roller Shutter com.fibaro.FGR224"
 + Bump dependencies

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,6 @@ export const API_URL_DEVICES = '/api/devices';
 export const API_URL_REFRESH_STATES = '/api/refreshStates';
 export const API_URL_GLOBAL_VARIABLES = '/api/globalVariables';
 
-// 
+//
 export const SECURITY_SYSTEM_GLOBAL_VARIABLE = 'SecuritySystem';
 

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -150,7 +150,8 @@ export class FibaroAccessory {
         }
       // Light / Switch / Outlet / Valve
       // for Wall Plug etc.
-      case 'FGWP': //FGWP101, FGWP102, FGWPG111, FGWPG121
+      case 'FGWP': //FGWP101, FGWP102
+      case 'FGWPG': //FGWPG111, FGWPG121
       case 'FGWOEF': //FGWOEF011
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
@@ -192,7 +193,8 @@ export class FibaroAccessory {
           break;
         }
       // Window Covering / Garage door
-      case 'FGR': //FGR221, FGRM222, FGR223, FGR223
+      case 'FGR': //FGR221, FGR223, FGR223
+      case 'FGRM': //FGRM222
       case 'FGWR': //FGWR111
       case 'rollerShutter':
       case 'remoteBaseShutter':

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -199,7 +199,7 @@ export class FibaroAccessory {
       case 'baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
         // it's a garage door
         // case 57 - gate with positioning
-        if (control56 || control57) {
+        if (controlType === 56 || controlType === 57) {
           service = this.platform.Service.GarageDoorOpener;
           this.mainCharacteristics =
             [this.platform.Characteristic.CurrentDoorState,
@@ -207,7 +207,7 @@ export class FibaroAccessory {
               this.platform.Characteristic.ObstructionDetected];
           break;
         } else if (this.device.type !== 'com.fibaro.baseShutter' ||
-                   this.device.'com.fibaro.baseShutter' && properties.favoritePositionsNativeSupport) {
+                   this.device.type === 'com.fibaro.baseShutter' && properties.favoritePositionsNativeSupport) {
           service = this.platform.Service.WindowCovering;
           this.mainCharacteristics = [
             this.platform.Characteristic.CurrentPosition,
@@ -215,13 +215,13 @@ export class FibaroAccessory {
             this.platform.Characteristic.PositionState,
             this.platform.Characteristic.HoldPosition,
           ];
-          if (control55) {
+          if (controlType === 55) {
             this.mainCharacteristics.push(
               this.platform.Characteristic.CurrentHorizontalTiltAngle,
               this.platform.Characteristic.TargetHorizontalTiltAngle,
             );
           }
-          if (this.device.'com.fibaro.remoteBaseShutter' || this.device.'com.fibaro.baseShutter') {
+          if (this.device.type === 'com.fibaro.remoteBaseShutter' || this.device.type === 'com.fibaro.baseShutter') {
             subtype = device.id + '--OPENCLOSEONLY';
           }
           break;

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -52,7 +52,7 @@ export class FibaroAccessory {
       
       case type.startsWith('com.fibaro.FGD') && !type.startsWith('com.fibaro.FGDW'): //FGD212
       case type.startsWith('com.fibaro.FGWD') && !type.startsWith('com.fibaro.FGWDS'): //FGWD111
-      case type == 'com.fibaro.multilevelSwitch':
+      case type === 'com.fibaro.multilevelSwitch':
         switch (controlType) {
           case 2: // Lighting
           case 23: // Lighting
@@ -66,11 +66,8 @@ export class FibaroAccessory {
         }
         break;
       // Light RGBW
-      case type.startsWith('com.fibaro.FGRGBW'):
-        // case type == 'com.fibaro.FGRGBW441M':
-        // case type == 'com.fibaro.FGRGBW442':
-        // case type == 'com.fibaro.FGRGBW442CC':
-      case type == 'com.fibaro.colorController':
+      case type.startsWith('com.fibaro.FGRGBW'): //FGRGBW441M, FGRGBW442, FGRGBW442CC
+      case type === 'com.fibaro.colorController':
         service = this.platform.Service.Lightbulb;
         this.mainCharacteristics =
           [this.platform.Characteristic.On,
@@ -80,11 +77,10 @@ export class FibaroAccessory {
         break;
       // Light / Switch / Outlet / Valve
       // for Switch / Double Switch / Smart Implant / etc.
-      case type.startsWith('com.fibaro.FGWDS'):
-        //case type == 'com.fibaro.FGWDS221':
-      case type == 'com.fibaro.binarySwitch':
-      case type == 'com.fibaro.developer.bxs.virtualBinarySwitch':
-      case type == 'com.fibaro.satelOutput':   
+      case type.startsWith('com.fibaro.FGWDS'): //FGWDS221
+      case type === 'com.fibaro.binarySwitch':
+      case type === 'com.fibaro.developer.bxs.virtualBinarySwitch':
+      case type === 'com.fibaro.satelOutput':   
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting
@@ -153,13 +149,8 @@ export class FibaroAccessory {
         }
       // Light / Switch / Outlet / Valve
       // for Wall Plug etc.
-      case type.startsWith('com.fibaro.FGWP'):
-        // case type == 'com.fibaro.FGWP101':
-        // case type == 'com.fibaro.FGWP102':
-        // case type == 'com.fibaro.FGWPG111':
-        // case type == 'com.fibaro.FGWPG121':
-      case type.startsWith('com.fibaro.FGWOEF'):
-        // case type == 'com.fibaro.FGWOEF011':
+      case type.startsWith('com.fibaro.FGWP'): //FGWP101, FGWP102, FGWPG111, FGWPG121
+      case type.startsWith('com.fibaro.FGWOEF'): //FGWOEF011
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting
@@ -200,16 +191,11 @@ export class FibaroAccessory {
           break;
         }
       // Window Covering / Garage door
-      case type.startsWith('com.fibaro.FGR') && !type.startsWith('com.fibaro.FGRGBW'):
-        // case type == 'com.fibaro.FGR221':
-        // case type == 'com.fibaro.FGRM222':
-        // case type == 'com.fibaro.FGR223':
-        // case type == 'com.fibaro.FGR224':
-      case type.startsWith('com.fibaro.FGWR'):
-        // case type == 'com.fibaro.FGWR111':
-      case type == 'com.fibaro.rollerShutter':
-      case type == 'com.fibaro.remoteBaseShutter':
-      case type == 'com.fibaro.baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
+      case type.startsWith('com.fibaro.FGR') && !type.startsWith('com.fibaro.FGRGBW'): //FGR221, FGRM222, FGR223, FGR223
+      case type.startsWith('com.fibaro.FGWR'): //FGWR111
+      case type === 'com.fibaro.rollerShutter':
+      case type === 'com.fibaro.remoteBaseShutter':
+      case type === 'com.fibaro.baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
         // it's a garage door
         // case 57 - gate with positioning
         if (controlType === 56 || controlType === 57) {
@@ -241,8 +227,8 @@ export class FibaroAccessory {
         }
       // Garage door
       // eslint-disable-next-line no-duplicate-case, no-fallthrough
-      case type == 'com.fibaro.baseShutter':
-      case type == 'com.fibaro.barrier':
+      case type === 'com.fibaro.baseShutter':
+      case type === 'com.fibaro.barrier':
         service = this.platform.Service.GarageDoorOpener;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentDoorState,
@@ -250,22 +236,22 @@ export class FibaroAccessory {
             this.platform.Characteristic.ObstructionDetected];
         break;
       // Temperature sensor
-      case type == 'com.fibaro.temperatureSensor':
+      case type === 'com.fibaro.temperatureSensor':
         service = this.platform.Service.TemperatureSensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentTemperature];
         break;
       // Humidity sensor
-      case type == 'com.fibaro.humiditySensor':
+      case type === 'com.fibaro.humiditySensor':
         service = this.platform.Service.HumiditySensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentRelativeHumidity];
         break;
       // Light sensor
-      case type == 'com.fibaro.lightSensor':
+      case type === 'com.fibaro.lightSensor':
         service = this.platform.Service.LightSensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentAmbientLightLevel];
         break;
       // Temperature sensor / Humidity sensor / Light sensor
-      case type == 'com.fibaro.multilevelSensor':
+      case type === 'com.fibaro.multilevelSensor':
         switch (properties.deviceRole) {
           case 'TemperatureSensor':
             service = this.platform.Service.TemperatureSensor;
@@ -286,21 +272,18 @@ export class FibaroAccessory {
         }
         break;
       // Motion sensor
-      case type.startsWith('com.fibaro.FGMS'):
-        // case type == 'com.fibaro.FGMS001':
-        // case type == 'com.fibaro.FGMS001v2':
-      case type == 'com.fibaro.motionSensor':
+      case type.startsWith('com.fibaro.FGMS'): //FGMS001, FGMS001v2
+      case type === 'com.fibaro.motionSensor':
         service = this.platform.Service.MotionSensor;
         this.mainCharacteristics = [this.platform.Characteristic.MotionDetected];
         break;
       // Doorbell / Contact sensor
-      case type.startsWith('com.fibaro.FGDW'):
-        // case type == 'com.fibaro.FGDW002':
-      case type == 'com.fibaro.binarySensor':
-      case type == 'com.fibaro.doorSensor':
-      case type == 'com.fibaro.windowSensor':
-      case type == 'com.fibaro.satelZone':
-      case type == 'com.fibaro.doorWindowSensor':
+      case type.startsWith('com.fibaro.FGDW'): //FGDW002
+      case type === 'com.fibaro.binarySensor':
+      case type === 'com.fibaro.doorSensor':
+      case type === 'com.fibaro.windowSensor':
+      case type === 'com.fibaro.satelZone':
+      case type === 'com.fibaro.doorWindowSensor':
         if (properties.deviceRole === 'MotionSensor') {
           service = this.platform.Service.MotionSensor;
           this.mainCharacteristics = [this.platform.Characteristic.MotionDetected];
@@ -313,23 +296,20 @@ export class FibaroAccessory {
         }
         break;
       // Leak sensor
-      case type.startsWith('com.fibaro.FGFS'):
-      //case type == 'com.fibaro.FGFS101':
-      case type == 'com.fibaro.floodSensor':
+      case type.startsWith('com.fibaro.FGFS'): //FGFS101
+      case type === 'com.fibaro.floodSensor':
         service = this.platform.Service.LeakSensor;
         this.mainCharacteristics = [this.platform.Characteristic.LeakDetected];
         break;
       // Smoke sensor
-      case type.startsWith('com.fibaro.FGSS'):
-      // case type == 'com.fibaro.FGSS001':
-      case type == 'com.fibaro.smokeSensor':
-      case type == 'com.fibaro.gasDetector':
+      case type.startsWith('com.fibaro.FGSS'): //FGSS001
+      case type === 'com.fibaro.smokeSensor':
+      case type === 'com.fibaro.gasDetector':
         service = this.platform.Service.SmokeSensor;
         this.mainCharacteristics = [this.platform.Characteristic.SmokeDetected];
         break;
       // Carbon Monoxide Sensor
-      case type.startsWith('com.fibaro.FGCD'):
-      // case type == 'com.fibaro.FGCD001':
+      case type.startsWith('com.fibaro.FGCD'): //FGCD001
         service = this.platform.Service.CarbonMonoxideSensor;
         this.mainCharacteristics =
           [this.platform.Characteristic.CarbonMonoxideDetected,
@@ -337,13 +317,13 @@ export class FibaroAccessory {
             this.platform.Characteristic.CarbonMonoxidePeakLevel, this.platform.Characteristic.BatteryLevel];
         break;
       // Lock Mechanism
-      case type == 'com.fibaro.doorLock':
-      case type == 'com.fibaro.gerda':
+      case type === 'com.fibaro.doorLock':
+      case type === 'com.fibaro.gerda':
         service = this.platform.Service.LockMechanism;
         this.mainCharacteristics = [this.platform.Characteristic.LockCurrentState, this.platform.Characteristic.LockTargetState];
         break;
       // Security system
-      case type == 'securitySystem':
+      case type === 'securitySystem':
         service = this.platform.Service.SecuritySystem;
         this.mainCharacteristics =
           [this.platform.Characteristic.SecuritySystemCurrentState,
@@ -351,13 +331,13 @@ export class FibaroAccessory {
         subtype = '0--';
         break;
       // Scene
-      case type == 'scene':
+      case type === 'scene':
         service = this.platform.Service.Switch;
         this.mainCharacteristics = [this.platform.Characteristic.On];
         subtype = device.id + '--SC';
         break;
       // Climate zone (HC3)
-      case type == 'climateZone':
+      case type === 'climateZone':
         service = this.platform.Service.Thermostat;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentTemperature,
@@ -368,7 +348,7 @@ export class FibaroAccessory {
         subtype = device.id + '--CZ';
         break;
       // Heating zone (HC2 and HCL)
-      case type == 'heatingZone':
+      case type === 'heatingZone':
         service = this.platform.Service.Thermostat;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentTemperature,
@@ -379,13 +359,13 @@ export class FibaroAccessory {
         subtype = device.id + '--HZ';
         break;
       // Global variables
-      case type == 'G':
+      case type === 'G':
         service = this.platform.Service.Switch;
         this.mainCharacteristics = [this.platform.Characteristic.On];
         subtype = this.device.type + '-' + this.device.name + '-';
         break;
       // Dimmer global variables
-      case type == 'D':
+      case type === 'D':
         service = this.platform.Service.Lightbulb;
         this.mainCharacteristics = [this.platform.Characteristic.On, this.platform.Characteristic.Brightness];
         subtype = this.device.type + '-' + this.device.name + '-';

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -50,10 +50,8 @@ export class FibaroAccessory {
     switch (true) {
       // Light / Dimmer
       
-      case type.startsWith('com.fibaro.FGD') && !type.startsWith('com.fibaro.FGDW'):
-         //case type == 'com.fibaro.FGD212':
-      case type.startsWith('com.fibaro.FGWD') && !type.startsWith('com.fibaro.FGWDS'):
-        //case type == 'com.fibaro.FGWD111':
+      case type.startsWith('com.fibaro.FGD') && !type.startsWith('com.fibaro.FGDW'): //FGD212
+      case type.startsWith('com.fibaro.FGWD') && !type.startsWith('com.fibaro.FGWDS'): //FGWD111
       case type == 'com.fibaro.multilevelSwitch':
         switch (controlType) {
           case 2: // Lighting

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -46,10 +46,10 @@ export class FibaroAccessory {
     let subtype = this.device.id + '----';
     const controlType = parseInt(properties.deviceControlType);
     const type = this.device.type;
-    
+
     switch (true) {
       // Light / Dimmer
-      
+
       case type.startsWith('com.fibaro.FGD') && !type.startsWith('com.fibaro.FGDW'): //FGD212
       case type.startsWith('com.fibaro.FGWD') && !type.startsWith('com.fibaro.FGWDS'): //FGWD111
       case type === 'com.fibaro.multilevelSwitch':
@@ -80,7 +80,7 @@ export class FibaroAccessory {
       case type.startsWith('com.fibaro.FGWDS'): //FGWDS221
       case type === 'com.fibaro.binarySwitch':
       case type === 'com.fibaro.developer.bxs.virtualBinarySwitch':
-      case type === 'com.fibaro.satelOutput':   
+      case type === 'com.fibaro.satelOutput':
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -193,7 +193,7 @@ export class FibaroAccessory {
           break;
         }
       // Window Covering / Garage door
-      case 'FGR': //FGR221, FGR223, FGR223
+      case 'FGR': //FGR221, FGR223
       case 'FGRM': //FGRM222
       case 'FGWR': //FGWR111
       case 'rollerShutter':

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -45,12 +45,16 @@ export class FibaroAccessory {
     let service;
     let subtype = this.device.id + '----';
     const controlType = parseInt(properties.deviceControlType);
-
-    switch (this.device.type) {
+    const type = this.device.type;
+    
+    switch (true) {
       // Light / Dimmer
-      case 'com.fibaro.multilevelSwitch':
-      case 'com.fibaro.FGD212':
-      case 'com.fibaro.FGWD111':
+      
+      case type.startsWith('com.fibaro.FGD') && !type.startsWith('com.fibaro.FGDW'):
+         //case type == 'com.fibaro.FGD212':
+      case type.startsWith('com.fibaro.FGWD') && !type.startsWith('com.fibaro.FGWDS'):
+        //case type == 'com.fibaro.FGWD111':
+      case type == 'com.fibaro.multilevelSwitch':
         switch (controlType) {
           case 2: // Lighting
           case 23: // Lighting
@@ -64,10 +68,11 @@ export class FibaroAccessory {
         }
         break;
       // Light RGBW
-      case 'com.fibaro.FGRGBW441M':
-      case 'com.fibaro.colorController':
-      case 'com.fibaro.FGRGBW442':
-      case 'com.fibaro.FGRGBW442CC':
+      case type.startsWith('com.fibaro.FGRGBW'):
+        // case type == 'com.fibaro.FGRGBW441M':
+        // case type == 'com.fibaro.FGRGBW442':
+        // case type == 'com.fibaro.FGRGBW442CC':
+      case type == 'com.fibaro.colorController':
         service = this.platform.Service.Lightbulb;
         this.mainCharacteristics =
           [this.platform.Characteristic.On,
@@ -77,10 +82,11 @@ export class FibaroAccessory {
         break;
       // Light / Switch / Outlet / Valve
       // for Switch / Double Switch / Smart Implant / etc.
-      case 'com.fibaro.binarySwitch':
-      case 'com.fibaro.developer.bxs.virtualBinarySwitch':
-      case 'com.fibaro.satelOutput':
-      case 'com.fibaro.FGWDS221':
+      case type.startsWith('com.fibaro.FGWDS'):
+        //case type == 'com.fibaro.FGWDS221':
+      case type == 'com.fibaro.binarySwitch':
+      case type == 'com.fibaro.developer.bxs.virtualBinarySwitch':
+      case type == 'com.fibaro.satelOutput':   
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting
@@ -149,11 +155,13 @@ export class FibaroAccessory {
         }
       // Light / Switch / Outlet / Valve
       // for Wall Plug etc.
-      case 'com.fibaro.FGWP101':
-      case 'com.fibaro.FGWP102':
-      case 'com.fibaro.FGWPG111':
-      case 'com.fibaro.FGWPG121':
-      case 'com.fibaro.FGWOEF011':
+      case type.startsWith('com.fibaro.FGWP'):
+        // case type == 'com.fibaro.FGWP101':
+        // case type == 'com.fibaro.FGWP102':
+        // case type == 'com.fibaro.FGWPG111':
+        // case type == 'com.fibaro.FGWPG121':
+      case type.startsWith('com.fibaro.FGWOEF'):
+        // case type == 'com.fibaro.FGWOEF011':
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting
@@ -194,14 +202,16 @@ export class FibaroAccessory {
           break;
         }
       // Window Covering / Garage door
-      case 'com.fibaro.FGR221':
-      case 'com.fibaro.FGRM222':
-      case 'com.fibaro.FGR223':
-      case 'com.fibaro.FGR224':
-      case 'com.fibaro.rollerShutter':
-      case 'com.fibaro.FGWR111':
-      case 'com.fibaro.remoteBaseShutter':
-      case 'com.fibaro.baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
+      case type.startsWith('com.fibaro.FGR') && !type.startsWith('com.fibaro.FGRGBW'):
+        // case type == 'com.fibaro.FGR221':
+        // case type == 'com.fibaro.FGRM222':
+        // case type == 'com.fibaro.FGR223':
+        // case type == 'com.fibaro.FGR224':
+      case type.startsWith('com.fibaro.FGWR'):
+        // case type == 'com.fibaro.FGWR111':
+      case type == 'com.fibaro.rollerShutter':
+      case type == 'com.fibaro.remoteBaseShutter':
+      case type == 'com.fibaro.baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
         // it's a garage door
         // case 57 - gate with positioning
         if (controlType === 56 || controlType === 57) {
@@ -233,8 +243,8 @@ export class FibaroAccessory {
         }
       // Garage door
       // eslint-disable-next-line no-duplicate-case, no-fallthrough
-      case 'com.fibaro.baseShutter':
-      case 'com.fibaro.barrier':
+      case type == 'com.fibaro.baseShutter':
+      case type == 'com.fibaro.barrier':
         service = this.platform.Service.GarageDoorOpener;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentDoorState,
@@ -242,22 +252,22 @@ export class FibaroAccessory {
             this.platform.Characteristic.ObstructionDetected];
         break;
       // Temperature sensor
-      case 'com.fibaro.temperatureSensor':
+      case type == 'com.fibaro.temperatureSensor':
         service = this.platform.Service.TemperatureSensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentTemperature];
         break;
       // Humidity sensor
-      case 'com.fibaro.humiditySensor':
+      case type == 'com.fibaro.humiditySensor':
         service = this.platform.Service.HumiditySensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentRelativeHumidity];
         break;
       // Light sensor
-      case 'com.fibaro.lightSensor':
+      case type == 'com.fibaro.lightSensor':
         service = this.platform.Service.LightSensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentAmbientLightLevel];
         break;
       // Temperature sensor / Humidity sensor / Light sensor
-      case 'com.fibaro.multilevelSensor':
+      case type == 'com.fibaro.multilevelSensor':
         switch (properties.deviceRole) {
           case 'TemperatureSensor':
             service = this.platform.Service.TemperatureSensor;
@@ -278,19 +288,21 @@ export class FibaroAccessory {
         }
         break;
       // Motion sensor
-      case 'com.fibaro.FGMS001':
-      case 'com.fibaro.FGMS001v2':
-      case 'com.fibaro.motionSensor':
+      case type.startsWith('com.fibaro.FGMS'):
+        // case type == 'com.fibaro.FGMS001':
+        // case type == 'com.fibaro.FGMS001v2':
+      case type == 'com.fibaro.motionSensor':
         service = this.platform.Service.MotionSensor;
         this.mainCharacteristics = [this.platform.Characteristic.MotionDetected];
         break;
       // Doorbell / Contact sensor
-      case 'com.fibaro.binarySensor':
-      case 'com.fibaro.doorSensor':
-      case 'com.fibaro.FGDW002':
-      case 'com.fibaro.windowSensor':
-      case 'com.fibaro.satelZone':
-      case 'com.fibaro.doorWindowSensor':
+      case type.startsWith('com.fibaro.FGDW'):
+        // case type == 'com.fibaro.FGDW002':
+      case type == 'com.fibaro.binarySensor':
+      case type == 'com.fibaro.doorSensor':
+      case type == 'com.fibaro.windowSensor':
+      case type == 'com.fibaro.satelZone':
+      case type == 'com.fibaro.doorWindowSensor':
         if (properties.deviceRole === 'MotionSensor') {
           service = this.platform.Service.MotionSensor;
           this.mainCharacteristics = [this.platform.Characteristic.MotionDetected];
@@ -303,20 +315,23 @@ export class FibaroAccessory {
         }
         break;
       // Leak sensor
-      case 'com.fibaro.FGFS101':
-      case 'com.fibaro.floodSensor':
+      case type.startsWith('com.fibaro.FGFS'):
+      //case type == 'com.fibaro.FGFS101':
+      case type == 'com.fibaro.floodSensor':
         service = this.platform.Service.LeakSensor;
         this.mainCharacteristics = [this.platform.Characteristic.LeakDetected];
         break;
       // Smoke sensor
-      case 'com.fibaro.FGSS001':
-      case 'com.fibaro.smokeSensor':
-      case 'com.fibaro.gasDetector':
+      case type.startsWith('com.fibaro.FGSS'):
+      // case type == 'com.fibaro.FGSS001':
+      case type == 'com.fibaro.smokeSensor':
+      case type == 'com.fibaro.gasDetector':
         service = this.platform.Service.SmokeSensor;
         this.mainCharacteristics = [this.platform.Characteristic.SmokeDetected];
         break;
       // Carbon Monoxide Sensor
-      case 'com.fibaro.FGCD001':
+      case type.startsWith('com.fibaro.FGCD'):
+      // case type == 'com.fibaro.FGCD001':
         service = this.platform.Service.CarbonMonoxideSensor;
         this.mainCharacteristics =
           [this.platform.Characteristic.CarbonMonoxideDetected,
@@ -324,13 +339,13 @@ export class FibaroAccessory {
             this.platform.Characteristic.CarbonMonoxidePeakLevel, this.platform.Characteristic.BatteryLevel];
         break;
       // Lock Mechanism
-      case 'com.fibaro.doorLock':
-      case 'com.fibaro.gerda':
+      case type == 'com.fibaro.doorLock':
+      case type == 'com.fibaro.gerda':
         service = this.platform.Service.LockMechanism;
         this.mainCharacteristics = [this.platform.Characteristic.LockCurrentState, this.platform.Characteristic.LockTargetState];
         break;
       // Security system
-      case 'securitySystem':
+      case type == 'securitySystem':
         service = this.platform.Service.SecuritySystem;
         this.mainCharacteristics =
           [this.platform.Characteristic.SecuritySystemCurrentState,
@@ -338,13 +353,13 @@ export class FibaroAccessory {
         subtype = '0--';
         break;
       // Scene
-      case 'scene':
+      case type == 'scene':
         service = this.platform.Service.Switch;
         this.mainCharacteristics = [this.platform.Characteristic.On];
         subtype = device.id + '--SC';
         break;
       // Climate zone (HC3)
-      case 'climateZone':
+      case type == 'climateZone':
         service = this.platform.Service.Thermostat;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentTemperature,
@@ -355,7 +370,7 @@ export class FibaroAccessory {
         subtype = device.id + '--CZ';
         break;
       // Heating zone (HC2 and HCL)
-      case 'heatingZone':
+      case type == 'heatingZone':
         service = this.platform.Service.Thermostat;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentTemperature,
@@ -366,13 +381,13 @@ export class FibaroAccessory {
         subtype = device.id + '--HZ';
         break;
       // Global variables
-      case 'G':
+      case type == 'G':
         service = this.platform.Service.Switch;
         this.mainCharacteristics = [this.platform.Characteristic.On];
         subtype = this.device.type + '-' + this.device.name + '-';
         break;
       // Dimmer global variables
-      case 'D':
+      case type == 'D':
         service = this.platform.Service.Lightbulb;
         this.mainCharacteristics = [this.platform.Characteristic.On, this.platform.Characteristic.Brightness];
         subtype = this.device.type + '-' + this.device.name + '-';

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -45,14 +45,15 @@ export class FibaroAccessory {
     let service;
     let subtype = this.device.id + '----';
     const controlType = parseInt(properties.deviceControlType);
-    const type = this.device.type;
+    let type = this.device.type;
+    type = type.replace('com.fibaro.',''); //remove 'com.fibaro.'
+    type = type.split(/\d/, 1).join().trim(); //remove everything from first digit
 
-    switch (true) {
+    switch (type) {
       // Light / Dimmer
-
-      case type.startsWith('com.fibaro.FGD') && !type.startsWith('com.fibaro.FGDW'): //FGD212
-      case type.startsWith('com.fibaro.FGWD') && !type.startsWith('com.fibaro.FGWDS'): //FGWD111
-      case type === 'com.fibaro.multilevelSwitch':
+      case 'FGD': //FGD212
+      case 'FGWD': //FGWD111
+      case 'multilevelSwitch':
         switch (controlType) {
           case 2: // Lighting
           case 23: // Lighting
@@ -66,8 +67,8 @@ export class FibaroAccessory {
         }
         break;
       // Light RGBW
-      case type.startsWith('com.fibaro.FGRGBW'): //FGRGBW441M, FGRGBW442, FGRGBW442CC
-      case type === 'com.fibaro.colorController':
+      case 'FGRGBW': //FGRGBW441M, FGRGBW442, FGRGBW442CC
+      case 'colorController':
         service = this.platform.Service.Lightbulb;
         this.mainCharacteristics =
           [this.platform.Characteristic.On,
@@ -77,10 +78,10 @@ export class FibaroAccessory {
         break;
       // Light / Switch / Outlet / Valve
       // for Switch / Double Switch / Smart Implant / etc.
-      case type.startsWith('com.fibaro.FGWDS'): //FGWDS221
-      case type === 'com.fibaro.binarySwitch':
-      case type === 'com.fibaro.developer.bxs.virtualBinarySwitch':
-      case type === 'com.fibaro.satelOutput':
+      case 'FGWDS': //FGWDS221
+      case 'binarySwitch':
+      case 'developer.bxs.virtualBinarySwitch':
+      case 'satelOutput':
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting
@@ -149,8 +150,8 @@ export class FibaroAccessory {
         }
       // Light / Switch / Outlet / Valve
       // for Wall Plug etc.
-      case type.startsWith('com.fibaro.FGWP'): //FGWP101, FGWP102, FGWPG111, FGWPG121
-      case type.startsWith('com.fibaro.FGWOEF'): //FGWOEF011
+      case 'FGWP': //FGWP101, FGWP102, FGWPG111, FGWPG121
+      case 'FGWOEF': //FGWOEF011
         if (this.platform.config.advControl === 1) {
           switch (controlType) {
             case 2: // Lighting
@@ -191,14 +192,14 @@ export class FibaroAccessory {
           break;
         }
       // Window Covering / Garage door
-      case type.startsWith('com.fibaro.FGR') && !type.startsWith('com.fibaro.FGRGBW'): //FGR221, FGRM222, FGR223, FGR223
-      case type.startsWith('com.fibaro.FGWR'): //FGWR111
-      case type === 'com.fibaro.rollerShutter':
-      case type === 'com.fibaro.remoteBaseShutter':
-      case type === 'com.fibaro.baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
+      case 'FGR': //FGR221, FGRM222, FGR223, FGR223
+      case 'FGWR': //FGWR111
+      case 'rollerShutter':
+      case 'remoteBaseShutter':
+      case 'baseShutter': // only if favoritePositionsNativeSupport is true otherwise it's a garage door
         // it's a garage door
         // case 57 - gate with positioning
-        if (controlType === 56 || controlType === 57) {
+        if (control56 || control57) {
           service = this.platform.Service.GarageDoorOpener;
           this.mainCharacteristics =
             [this.platform.Characteristic.CurrentDoorState,
@@ -206,7 +207,7 @@ export class FibaroAccessory {
               this.platform.Characteristic.ObstructionDetected];
           break;
         } else if (this.device.type !== 'com.fibaro.baseShutter' ||
-                   this.device.type === 'com.fibaro.baseShutter' && properties.favoritePositionsNativeSupport) {
+                   this.device.'com.fibaro.baseShutter' && properties.favoritePositionsNativeSupport) {
           service = this.platform.Service.WindowCovering;
           this.mainCharacteristics = [
             this.platform.Characteristic.CurrentPosition,
@@ -214,21 +215,21 @@ export class FibaroAccessory {
             this.platform.Characteristic.PositionState,
             this.platform.Characteristic.HoldPosition,
           ];
-          if (controlType === 55) {
+          if (control55) {
             this.mainCharacteristics.push(
               this.platform.Characteristic.CurrentHorizontalTiltAngle,
               this.platform.Characteristic.TargetHorizontalTiltAngle,
             );
           }
-          if (this.device.type === 'com.fibaro.remoteBaseShutter' || this.device.type === 'com.fibaro.baseShutter') {
+          if (this.device.'com.fibaro.remoteBaseShutter' || this.device.'com.fibaro.baseShutter') {
             subtype = device.id + '--OPENCLOSEONLY';
           }
           break;
         }
       // Garage door
       // eslint-disable-next-line no-duplicate-case, no-fallthrough
-      case type === 'com.fibaro.baseShutter':
-      case type === 'com.fibaro.barrier':
+      case 'baseShutter':
+      case 'barrier':
         service = this.platform.Service.GarageDoorOpener;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentDoorState,
@@ -236,22 +237,22 @@ export class FibaroAccessory {
             this.platform.Characteristic.ObstructionDetected];
         break;
       // Temperature sensor
-      case type === 'com.fibaro.temperatureSensor':
+      case 'temperatureSensor':
         service = this.platform.Service.TemperatureSensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentTemperature];
         break;
       // Humidity sensor
-      case type === 'com.fibaro.humiditySensor':
+      case 'humiditySensor':
         service = this.platform.Service.HumiditySensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentRelativeHumidity];
         break;
       // Light sensor
-      case type === 'com.fibaro.lightSensor':
+      case 'lightSensor':
         service = this.platform.Service.LightSensor;
         this.mainCharacteristics = [this.platform.Characteristic.CurrentAmbientLightLevel];
         break;
       // Temperature sensor / Humidity sensor / Light sensor
-      case type === 'com.fibaro.multilevelSensor':
+      case 'multilevelSensor':
         switch (properties.deviceRole) {
           case 'TemperatureSensor':
             service = this.platform.Service.TemperatureSensor;
@@ -272,18 +273,18 @@ export class FibaroAccessory {
         }
         break;
       // Motion sensor
-      case type.startsWith('com.fibaro.FGMS'): //FGMS001, FGMS001v2
-      case type === 'com.fibaro.motionSensor':
+      case 'FGMS': //FGMS001, FGMS001v2
+      case 'motionSensor':
         service = this.platform.Service.MotionSensor;
         this.mainCharacteristics = [this.platform.Characteristic.MotionDetected];
         break;
       // Doorbell / Contact sensor
-      case type.startsWith('com.fibaro.FGDW'): //FGDW002
-      case type === 'com.fibaro.binarySensor':
-      case type === 'com.fibaro.doorSensor':
-      case type === 'com.fibaro.windowSensor':
-      case type === 'com.fibaro.satelZone':
-      case type === 'com.fibaro.doorWindowSensor':
+      case 'FGDW': //FGDW002
+      case 'binarySensor':
+      case 'doorSensor':
+      case 'windowSensor':
+      case 'satelZone':
+      case 'doorWindowSensor':
         if (properties.deviceRole === 'MotionSensor') {
           service = this.platform.Service.MotionSensor;
           this.mainCharacteristics = [this.platform.Characteristic.MotionDetected];
@@ -296,20 +297,20 @@ export class FibaroAccessory {
         }
         break;
       // Leak sensor
-      case type.startsWith('com.fibaro.FGFS'): //FGFS101
-      case type === 'com.fibaro.floodSensor':
+      case 'FGFS': //FGFS101
+      case 'floodSensor':
         service = this.platform.Service.LeakSensor;
         this.mainCharacteristics = [this.platform.Characteristic.LeakDetected];
         break;
       // Smoke sensor
-      case type.startsWith('com.fibaro.FGSS'): //FGSS001
-      case type === 'com.fibaro.smokeSensor':
-      case type === 'com.fibaro.gasDetector':
+      case 'FGSS': //FGSS001
+      case 'smokeSensor':
+      case 'gasDetector':
         service = this.platform.Service.SmokeSensor;
         this.mainCharacteristics = [this.platform.Characteristic.SmokeDetected];
         break;
       // Carbon Monoxide Sensor
-      case type.startsWith('com.fibaro.FGCD'): //FGCD001
+      case 'FGCD': //FGCD001
         service = this.platform.Service.CarbonMonoxideSensor;
         this.mainCharacteristics =
           [this.platform.Characteristic.CarbonMonoxideDetected,
@@ -317,13 +318,13 @@ export class FibaroAccessory {
             this.platform.Characteristic.CarbonMonoxidePeakLevel, this.platform.Characteristic.BatteryLevel];
         break;
       // Lock Mechanism
-      case type === 'com.fibaro.doorLock':
-      case type === 'com.fibaro.gerda':
+      case 'doorLock':
+      case 'gerda':
         service = this.platform.Service.LockMechanism;
         this.mainCharacteristics = [this.platform.Characteristic.LockCurrentState, this.platform.Characteristic.LockTargetState];
         break;
       // Security system
-      case type === 'securitySystem':
+      case 'securitySystem':
         service = this.platform.Service.SecuritySystem;
         this.mainCharacteristics =
           [this.platform.Characteristic.SecuritySystemCurrentState,
@@ -331,13 +332,13 @@ export class FibaroAccessory {
         subtype = '0--';
         break;
       // Scene
-      case type === 'scene':
+      case 'scene':
         service = this.platform.Service.Switch;
         this.mainCharacteristics = [this.platform.Characteristic.On];
         subtype = device.id + '--SC';
         break;
       // Climate zone (HC3)
-      case type === 'climateZone':
+      case 'climateZone':
         service = this.platform.Service.Thermostat;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentTemperature,
@@ -348,7 +349,7 @@ export class FibaroAccessory {
         subtype = device.id + '--CZ';
         break;
       // Heating zone (HC2 and HCL)
-      case type === 'heatingZone':
+      case 'heatingZone':
         service = this.platform.Service.Thermostat;
         this.mainCharacteristics =
           [this.platform.Characteristic.CurrentTemperature,
@@ -359,13 +360,13 @@ export class FibaroAccessory {
         subtype = device.id + '--HZ';
         break;
       // Global variables
-      case type === 'G':
+      case 'G':
         service = this.platform.Service.Switch;
         this.mainCharacteristics = [this.platform.Characteristic.On];
         subtype = this.device.type + '-' + this.device.name + '-';
         break;
       // Dimmer global variables
-      case type === 'D':
+      case 'D':
         service = this.platform.Service.Lightbulb;
         this.mainCharacteristics = [this.platform.Characteristic.On, this.platform.Characteristic.Brightness];
         subtype = this.device.type + '-' + this.device.name + '-';

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -193,7 +193,7 @@ export class FibaroAccessory {
           break;
         }
       // Window Covering / Garage door
-      case 'FGR': //FGR221, FGR223
+      case 'FGR': //FGR221, FGR223, FGR224
       case 'FGRM': //FGRM222
       case 'FGWR': //FGWR111
       case 'rollerShutter':

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -46,7 +46,7 @@ export class FibaroAccessory {
     let subtype = this.device.id + '----';
     const controlType = parseInt(properties.deviceControlType);
     let type = this.device.type;
-    type = type.replace('com.fibaro.',''); //remove 'com.fibaro.'
+    type = type.replace('com.fibaro.', ''); //remove 'com.fibaro.'
     type = type.split(/\d/, 1).join().trim(); //remove everything from first digit
 
     switch (type) {


### PR DESCRIPTION
From device type string remove 'com.fibaro.' and everything from first digit.

E.G. instead: 'com.fibaro.FGD221' , 'com.fibaro.FGD222' , etc., will be 'FGD'.
E.G. instead: 'com.fibaro.baseShutter' , will be 'baseShutter'.

Some strings will stay as they are currently, like 'G' will stay 'G', 'securitySystem' will stay 'securitySystem'.

This will provide support for future devices.