### PR TITLE
Some small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,45 @@ This plugin can be easily installed through Homebridge UI or via [NPM](https://w
 # Configuration
 Configure the plugin through the settings UI or directly in the JSON editor.
 
-#### Required:
+<details>
+<summary><b>config.json example</b></summary>
 
 ```json
+
 {
   "platforms": [
     {
-        "platform": "FibaroHC",
-        "name": "FibaroHC",
-        "url": "PUT URL OR IP OF YOUR HOME CENTER HERE CONTAINING PROTOCOL AND NAME E.G.: https://hc-00000XXX.local OR IP E.G.: 192.168.1.100",
-        "username": "PUT USERNAME OF YOUR HOME CENTER HERE",
-        "password": "PUT PASSWORD OF YOUR HOME CENTER HERE"
+      "platform": "FibaroHC",
+      "name": "FibaroHC",
+      "url": "192.168.1.100",
+      "username": "mail@domain.com",
+      "password": "HCpassword123",
+      "pollerperiod": 3,
+      "thermostattimeout": 7200
+      "thermostatmaxtemperature": 100,
+      "switchglobalvariables": "24,78,54"
+      "dimmerglobalvariables": "12,56,81",
+      "adminUsername": "admin_name",
+      "adminPassword": "admin_password",
+      "securitysystem": "enabled",
+      "addRoomNameToDeviceName" : "disabled",
+      "doorbellDeviceId" : "21,88",
+      "logsLevel": 1,
+      "devices": [
+        {
+          "id": 42,
+          "displayAs": "switch",
+        },
+        {
+          "id": 58,
+          "displayAs": "exclude",
+        }
+      ]
     }
   ]
 }
-
 ```
-
+#### Basic fields (required)
 + `url` : url or IP of your Home Center / Yubii Home. Using https may be mandatory if you configured HC to use it. Examples:
   + `192.168.1.100` - replace with your IP
   + `https://hc-00000XXX.local` - replace with your HC serial, get ca.cer file from HC and put it in Homebridge in same folder as config.json
@@ -55,48 +77,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `username` : username of your Home Center / Yubii Home
 + `password` : password of your Home Center / Yubii Home
 
-
-<details>
-<summary><b>Advanced settings</b></summary>
-
-```json
-
-{
-    "bridge": {
-        "name": "Homebridge",
-        "username": "CC:22:3D:E3:CE:30",
-        "port": 51826,
-        "pin": "031-45-154"
-    },
-    
-    "description": "This is an example configuration file. You can use this as a template for creating your own configuration file.",
-
-    "platforms": [
-        {
-            "platform": "FibaroHC",
-            "name": "FibaroHC",
-            "url": "PUT URL OR IP OF YOUR HOME CENTER HERE CONTAINING PROTOCOL AND NAME E.G.: https://hc-00000XXX.local OR IP E.G.: 192.168.1.100",
-            "username": "PUT USERNAME OF YOUR HOME CENTER HERE",
-            "password": "PUT PASSWORD OF YOUR HOME CENTER HERE",
-            "pollerperiod": "PUT 0 FOR DISABLING POLLING (REFRESH INTERVAL), 1 - 100 INTERVAL IN SECONDS. 3 SECONDS IS THE DEFAULT",
-            "thermostattimeout": "NUMBER OF SECONDS FOR THERMOSTAT TIMEOUT, DEFAULT: 7200 (2 HOURS)"
-            "thermostatmaxtemperature": "SET MAX TEMPERATURE FOR THERMOSTATIC DEVICES (DEFAULT 100C)",
-            "switchglobalvariables": "PUT A COMMA SEPARATED LIST OF HOME CENTER GLOBAL VARIABLES ACTING LIKE A BISTABLE SWITCH",
-            "dimmerglobalvariables": "PUT A COMMA SEPARATED LIST OF HOME CENTER GLOBAL VARIABLES ACTING LIKE A DIMMER",
-            "adminUsername": "PUT ADMIN USERNAME OF YOUR HOME CENTER HERE TO SET GLOBAL VARIABLES",
-            "adminPassword": "PUT ADMIN PASSWORD OF YOUR HOME CENTER HERE TO SET GLOBAL VARIABLES",
-            "securitysystem": "PUT enabled OR disabled IN ORDER TO MANAGE THE AVAILABILITY OF THE SECURITY SYSTEM",
-            "addRoomNameToDeviceName" : "PUT enabled OR disabled IN ORDER TO ADD THE ROOM NAME TO DEVICE NAME. DEFAULT disabled",
-            "doorbellDeviceId" : "PUT HOME CENTER BINARY SENSOR DEVICE ID ACTING AS A DOORBELL",
-            "logsLevel": "PUT THE DESIRED LOG LEVEL: 0 DISABLED, 1 ONLY CHANGES, 2 ALL"
-        }
-    ],
-
-    "accessories": [
-    ]
-}
-```
-    
+#### Advanced
 + `pollerperiod` : Polling interval (refresh interval) for querying Fibaro Home Center (0: disabled, recomended: 3, 1 or 2 seconds allows for a more responsive update of the Home app when changes appear outside the HomeKit environment). If it is disabled the Home app is not updated automatically when such a change happen but only when you close a panel and reopen it. Enabling this option is useful to read the new state when controlling devices outside HomeKit, E.G.: via Fibaro, physical buttons, scenes and automations.
 + `thermostatmaxtemperature` : set max temperature for thermostatic devices (default 100 C)
 + `thermostattimeout` : number of seconds for the thermostat timeout, default: 7200 (2 hours)
@@ -109,41 +90,11 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `doorbellDeviceId` : home center binary sensor device id acting as a doorbell
 + `logsLevel` : desired log level: 0 disabled, 1 only changes, 2 all
 
-</details>
-
-
-<details>
-<summary><b>Individual device settings</b></summary>
-
-The ability to add individual settings for each device. Provide device ID and choose as which device to display. This way you can also add any device that is not currently supported pr exclude device. 
+#### Individual for each device
 + `id` : device ID (like: 42).
 + `displayAS` : display as: switch, dimmer, etc. or exclude device.
 
-```json
-{
-  "platforms": [
-    {
-        "platform": "FibaroHC",
-        "name": "FibaroHC",
-        "url": "PUT URL OR IP OF YOUR HOME CENTER HERE CONTAINING PROTOCOL AND NAME E.G.: https://hc-00000XXX.local OR IP E.G.: 192.168.1.100",
-        "username": "PUT USERNAME OF YOUR HOME CENTER HERE",
-        "password": "PUT PASSWORD OF YOUR HOME CENTER HERE",
-        "devices": [
-                {
-                    "id": 42,
-                    "displayAs": "switch",
-                },
-                {
-                    "id": 58,
-                    "displayAs": "exclude",
-                }
-            ]
-    }
-  ]
-}
-```
 </details>
-
 
 
 # Manuals

--- a/README.md
+++ b/README.md
@@ -222,11 +222,13 @@ If you have any issues with this plugin, enable all logs in plugin config and th
 
 # Contributing and support
 
-- Feel free to create [Issue](https://github.com/ilcato/homebridge-fibaro-home-center/issues) or [Pull Request](https://github.com/ilcato/homebridge-fibaro-home-center/pulls)
+Feel free to create [Issue](https://github.com/ilcato/homebridge-fibaro-home-center/issues) or [Pull Request](https://github.com/ilcato/homebridge-fibaro-home-center/pulls)
 
 # Disclaimer
 
-- This is not the official Fibaro plugin. The plugin uses the official API. Despite the efforts made, the operation of the plugin is without any guarantees and at your own risk.
+- This is not the official Fibaro plugin but it uses the official Fibaro API. 
+- Despite the efforts made, the operation of the plugin is without any guarantees and at your own risk.
+- All product and company names are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.
 
 # Latest release notes
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
       "adminPassword": "admin_password",
       "securitysystem": "enabled",
       "addRoomNameToDeviceName" : "disabled",
-      "doorbellDeviceId" : "21,88",
+      "doorbellDeviceId" : 21,
       "logsLevel": 1,
       "devices": [
         {
@@ -89,7 +89,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
 + `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
-+ `doorbellDeviceId` (string) : Home Center binary sensor device id acting as a doorbell.
++ `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
 + `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 
 #### Individual for each device

--- a/README.md
+++ b/README.md
@@ -239,15 +239,4 @@ Warning! Read carefully before updating!
 + Removed Advanced Control. If you have Advanced Control enabled before the update, nothing will change, if not, some devices can change the way they are displayed (this may require removal from the cache in Homebridge settings and/or reconfiguration in HomeKit). Now you can individually change the way that each device display.
 + Bump dependencies.
 
-### Version 1.7.5
-+ Added new Fibaro "Roller Shutter com.fibaro.FGR224"
-+ Bump dependencies
-
-### Version 1.7.4
-+ Manage Satel motion sensor
-+ Manage heating/climate zone id collision
-+ Small refactoring
-+ Bump dependencies
-
-
 #### See all: [Releases](https://github.com/ilcato/homebridge-fibaro-home-center/releases)

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Configure the plugin through the settings UI or directly in the JSON editor.
       "pollerperiod": 3,
       "thermostattimeout": 7200
       "thermostatmaxtemperature": 100,
-      "switchglobalvariables": "24,78,54"
-      "dimmerglobalvariables": "12,56,81",
+      "switchglobalvariables": "name1,name2,name3"
+      "dimmerglobalvariables": "name1,name2,name3",
       "adminUsername": "admin_name",
       "adminPassword": "admin_password",
       "securitysystem": "enabled",
@@ -83,8 +83,8 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `pollerperiod` (integer) : Polling interval (refresh interval) for querying Fibaro Home Center (0: disabled, recomended: 3, 1 or 2 seconds allows for a more responsive update of the Home app when changes appear outside the HomeKit environment). If it is disabled the Home app is not updated automatically when such a change happen but only when you close a panel and reopen it. Enabling this option is useful to read the new state when controlling devices outside HomeKit, E.G.: via Fibaro, physical buttons, scenes and automations.
 + `thermostatmaxtemperature` (integer) : Set max temperature for thermostatic devices (default 100 C).
 + `thermostattimeout` (integer) : Number of seconds for the thermostat timeout, default: 7200 (2 hours).
-+ `switchglobalvariables` (string) : Comma separated list of home center global variables acting like a bistable switch.
-+ `dimmerglobalvariables` (string) : Comma separated list of home center global variables acting like a dimmer.
++ `switchglobalvariables` (string) : Comma separated list of home center global variables names acting like a bistable switch.
++ `dimmerglobalvariables` (string) : Comma separated list of home center global variables names acting like a dimmer.
 + `adminUsername` (string) : Admin username of your home center, needed only to set global variables.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
 + `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
-+ `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
++ `doorbellDeviceId` (string) : Home Center binary sensor device id acting as a doorbell.
 + `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 
 #### Individual for each device

--- a/README.md
+++ b/README.md
@@ -71,28 +71,30 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 ```
 #### Basic fields (required)
 + `url` : url or IP of your Home Center / Yubii Home. Using https may be mandatory if you configured HC to use it. Examples:
-  + `192.168.1.100` - replace with your IP
-  + `https://hc-00000XXX.local` - replace with your HC serial, get ca.cer file from HC and put it in Homebridge in same folder as config.json
-  + `http://hc-00000XXX.local` - replace with your HC serial
-+ `username` : username of your Home Center / Yubii Home
-+ `password` : password of your Home Center / Yubii Home
+  + `192.168.1.100` - replace with your IP,
+  + `https://hc-00000XXX.local` - replace with your HC serial, get ca.cer file from HC and put it in Homebridge in same folder as config.json,
+  + `http://hc-00000XXX.local` - replace with your HC serial.
++ `username` : username of your Home Center / Yubii Home.
++ `password` : password of your Home Center / Yubii Home.
++ `platform` : platform name, must be 'FibaroHC'.
++ `name`: name of the plugin displayed in Homebridge log and as plugin bridge name, default 'FibaroHC'.
 
 #### Advanced
 + `pollerperiod` : Polling interval (refresh interval) for querying Fibaro Home Center (0: disabled, recomended: 3, 1 or 2 seconds allows for a more responsive update of the Home app when changes appear outside the HomeKit environment). If it is disabled the Home app is not updated automatically when such a change happen but only when you close a panel and reopen it. Enabling this option is useful to read the new state when controlling devices outside HomeKit, E.G.: via Fibaro, physical buttons, scenes and automations.
-+ `thermostatmaxtemperature` : set max temperature for thermostatic devices (default 100 C)
-+ `thermostattimeout` : number of seconds for the thermostat timeout, default: 7200 (2 hours)
-+ `switchglobalvariables` : comma separated list of home center global variables acting like a bistable switch
-+ `dimmerglobalvariables` : comma separated list of home center global variables acting like a dimmer
-+ `adminUsername`: admin username of your home center, needed only to set global variables,
-+ `adminPassword`: admin password of your home center, needed only to set global variables,
-+ `securitysystem` : enabled or disabled in order to manage the availability of the security system
-+ `addRoomNameToDeviceName` : If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
-+ `doorbellDeviceId` : home center binary sensor device id acting as a doorbell
-+ `logsLevel` : desired log level: 0 disabled, 1 only changes, 2 all
++ `thermostatmaxtemperature` : Set max temperature for thermostatic devices (default 100 C).
++ `thermostattimeout` : Number of seconds for the thermostat timeout, default: 7200 (2 hours).
++ `switchglobalvariables` : Comma separated list of home center global variables acting like a bistable switch.
++ `dimmerglobalvariables` : Comma separated list of home center global variables acting like a dimmer.
++ `adminUsername`: Admin username of your home center, needed only to set global variables.
++ `adminPassword`: Admin password of your home center, needed only to set global variables.
++ `securitysystem` : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
++ `addRoomNameToDeviceName` : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
++ `doorbellDeviceId` : Home Center binary sensor device id acting as a doorbell.
++ `logsLevel` : Desired log level: 0 disabled, 1 only changes, 2 all.
 
 #### Individual for each device
-+ `id` : device ID (like: 42).
-+ `displayAS` : display as: switch, dimmer, etc. or exclude device.
++ `id` : Device ID (like: 42).
++ `displayAS` : Display as: switch, dimmer, etc. or exclude device.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
       "name": "FibaroHC",
       "url": "192.168.1.100",
       "username": "mail@domain.com",
-      "password": "HCpassword123",
+      "password": "your-password",
       "pollerperiod": 3,
       "thermostattimeout": 7200
       "thermostatmaxtemperature": 100,

--- a/README.md
+++ b/README.md
@@ -70,27 +70,27 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 }
 ```
 #### Basic fields (required)
-+ `url` : url or IP of your Home Center / Yubii Home. Using https may be mandatory if you configured HC to use it. Examples:
++ `url` (string) : url or IP of your Home Center / Yubii Home. Using https may be mandatory if you configured HC to use it. Examples:
   + `192.168.1.100` - replace with your IP,
   + `https://hc-00000XXX.local` - replace with your HC serial, get ca.cer file from HC and put it in Homebridge in same folder as config.json,
   + `http://hc-00000XXX.local` - replace with your HC serial.
-+ `username` : username of your Home Center / Yubii Home.
-+ `password` : password of your Home Center / Yubii Home.
-+ `platform` : platform name, must be 'FibaroHC'.
-+ `name`: name of the plugin displayed in Homebridge log and as plugin bridge name, default 'FibaroHC'.
++ `username` (string) : username of your Home Center / Yubii Home.
++ `password` (string) : password of your Home Center / Yubii Home.
++ `platform` (string) : platform name, must be 'FibaroHC'.
++ `name` (string) : name of the plugin displayed in Homebridge log and as plugin bridge name, default 'FibaroHC'.
 
 #### Advanced
-+ `pollerperiod` : Polling interval (refresh interval) for querying Fibaro Home Center (0: disabled, recomended: 3, 1 or 2 seconds allows for a more responsive update of the Home app when changes appear outside the HomeKit environment). If it is disabled the Home app is not updated automatically when such a change happen but only when you close a panel and reopen it. Enabling this option is useful to read the new state when controlling devices outside HomeKit, E.G.: via Fibaro, physical buttons, scenes and automations.
-+ `thermostatmaxtemperature` : Set max temperature for thermostatic devices (default 100 C).
-+ `thermostattimeout` : Number of seconds for the thermostat timeout, default: 7200 (2 hours).
-+ `switchglobalvariables` : Comma separated list of home center global variables acting like a bistable switch.
-+ `dimmerglobalvariables` : Comma separated list of home center global variables acting like a dimmer.
-+ `adminUsername`: Admin username of your home center, needed only to set global variables.
-+ `adminPassword`: Admin password of your home center, needed only to set global variables.
-+ `securitysystem` : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
-+ `addRoomNameToDeviceName` : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
-+ `doorbellDeviceId` : Home Center binary sensor device id acting as a doorbell.
-+ `logsLevel` : Desired log level: 0 disabled, 1 only changes, 2 all.
++ `pollerperiod` (integer) : Polling interval (refresh interval) for querying Fibaro Home Center (0: disabled, recomended: 3, 1 or 2 seconds allows for a more responsive update of the Home app when changes appear outside the HomeKit environment). If it is disabled the Home app is not updated automatically when such a change happen but only when you close a panel and reopen it. Enabling this option is useful to read the new state when controlling devices outside HomeKit, E.G.: via Fibaro, physical buttons, scenes and automations.
++ `thermostatmaxtemperature` (integer) : Set max temperature for thermostatic devices (default 100 C).
++ `thermostattimeout` (integer) : Number of seconds for the thermostat timeout, default: 7200 (2 hours).
++ `switchglobalvariables` (string) : Comma separated list of home center global variables acting like a bistable switch.
++ `dimmerglobalvariables` (string) : Comma separated list of home center global variables acting like a dimmer.
++ `adminUsername` (string) : Admin username of your home center, needed only to set global variables.
++ `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
++ `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
++ `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
++ `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
++ `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 
 #### Individual for each device
 + `id` : Device ID (like: 42).

--- a/config.schema.json
+++ b/config.schema.json
@@ -132,26 +132,26 @@
       "logsLevel": {
         "description": "Choose what logs to display. The most important logs will be displayed regardless of this choice.",
         "title": "Logs Level",
-        "type": "number",
-        "default": "1",
+        "type": "integer",
+        "default": 1,
         "required": true,
         "oneOf": [
           {
             "title": "Disabled",
             "enum": [
-              "0"
+              0
             ]
           },
           {
             "title": "Only changes",
             "enum": [
-              "1"
+              1
             ]
           },
           {
             "title": "All Logs",
             "enum": [
-              "2"
+              2
             ]
           }
         ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "2.0.0",
   "description": "Homebridge plugin for Fibaro Home Center (2, 2 Lite, 3, 3 Lite, Yubii Home).",
   "author": "ilcato",
+  "maintainers": "ilcato",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "description": "Homebridge plugin for Fibaro Home Center (2, 2 Lite, 3, 3 Lite, Yubii Home).",
   "author": "ilcato",
-  "maintainers": "ilcato",
+  "maintainers": ["ilcato"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Simplify readme

Not sure about these:

- `switchglobalvariables` and `dimmerglobalvariables` : comma separated list , but list of what? Devices IDs? 

- `doorbellDeviceId` - one ID as integer? Not comma separated list as string?

## Fix in config.schema 

- change Logs level, from numbers type to integer

## Add maintainers to package.json

Due to NPM problems ([details here](https://github.com/homebridge/homebridge-config-ui-x/issues/2070)), added maintainers to package.json. Normally NPM add this.