### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "homebridge": "^1.6.0 || ^2.0.0-beta.0",
-    "node": "^18.20.4 || ^20.15.1"
+    "node": "^18.0.0 || ^20.0.0"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "https://github.com/ilcato/homebridge-fibaro-home-center/issues"
   },
   "engines": {
-    "node": ">=10.17.0",
-    "homebridge": ">=1.3.5"
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+    "node": "^18.20.4 || ^20.15.1"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/ilcato/homebridge-fibaro-home-center/issues"
   },
   "engines": {
-    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+    "homebridge": "^1.6.0 || ^2.0.0",
     "node": "^18.0.0 || ^20.0.0"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
- https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2
- https://github.com/npm/node-semver#versions

Homebridge support only even versions of node, so it cannot be e.g >= 16 cause it allow for 17, 19 etc versions. 