### PR TITLE
Option to select room name before device name + Small changes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `adminUsername` (string) : Admin username of your home center, needed only to set global variables.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
-+ `addRoomNameToDeviceName` (string) : Set 'enabled', 'enabledBefore' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located.
++ `addRoomNameToDeviceName` (string) : Set 'enabled', 'enabledBefore' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Warning: changing this may cause that some of your devices will be removed and add as new.
 + `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
 + `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 
 #### Advanced
 + `pollerperiod` (integer) : Polling interval (refresh interval) for querying Fibaro Home Center (0: disabled, recomended: 3, 1 or 2 seconds allows for a more responsive update of the Home app when changes appear outside the HomeKit environment). If it is disabled the Home app is not updated automatically when such a change happen but only when you close a panel and reopen it. Enabling this option is useful to read the new state when controlling devices outside HomeKit, E.G.: via Fibaro, physical buttons, scenes and automations.
-+ `markDeadDevices` (boolean) : Show dead devices as not responding in HomeKit. Dead devices are devices that have connection problems. Warning: Not responding devices will break HomeKit automations.
++ `markDeadDevices` (boolean) : Show dead devices as not responding in HomeKit. Dead devices are devices that have connection problems and in the Fibaro hub selected option to mark such devices. Warning: Not responding device in HomeKit can break automation, it is recommended to place such device in a separate automation.
 + `thermostatmaxtemperature` (integer) : Set max temperature for thermostatic devices (default 100 C).
 + `thermostattimeout` (integer) : Number of seconds for the thermostat timeout, default: 7200 (2 hours).
 + `switchglobalvariables` (string) : Comma separated list of home center global variables names acting like a bistable switch.
@@ -388,7 +388,8 @@ Feel free to create [Issue](https://github.com/ilcato/homebridge-fibaro-home-cen
 - Significant reduction in device response time.
 - Option to mark dead devices as not responding in HomeKit.
 - Log dead devices.
-- Improvements for poller. 
+- Improvements for poller.
+- Display Room name in device info.
 - Add support for Outlet in individual device config.
 - Dependencies updates.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `adminUsername` (string) : Admin username of your home center, needed only to set global variables.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
-+ `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
++ `addRoomNameToDeviceName` (string) : Set 'enabled', 'enabledBefore' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located.
 + `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
 + `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `adminUsername` (string) : Admin username of your home center, needed only to set global variables.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
-+ `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, each device name will be prepended with the name of the room in which it is located, e.g.: Bedroom Light. Default: disabled.
++ `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
 + `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
 + `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,8 @@ Feel free to create [Issue](https://github.com/ilcato/homebridge-fibaro-home-cen
 - Option to mark dead devices as not responding in HomeKit.
 - Log dead devices.
 - Improvements for poller.
-- Display Room name in device info.
+- Ability to add a room name before or after the device name.
+- Display room name in device info.
 - Add support for Outlet in individual device config.
 - Dependencies updates.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 + `adminUsername` (string) : Admin username of your home center, needed only to set global variables.
 + `adminPassword` (string) : Admin password of your home center, needed only to set global variables.
 + `securitysystem` (string) : Set 'enabled' or 'disabled' in order to manage the availability of the security system.
-+ `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.
++ `addRoomNameToDeviceName` (string) : Set 'enabled' or 'disabled'. If enabled, each device name will be prepended with the name of the room in which it is located, e.g.: Bedroom Light. Default: disabled.
 + `doorbellDeviceId` (integer) : Home Center binary sensor device id acting as a doorbell.
 + `logsLevel` (integer) : Desired log level: 0 disabled, 1 only changes, 2 all.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -42,7 +42,7 @@
         "minimum": 0
       },
       "markDeadDevices": {
-        "description": "Show dead devices as not responding in HomeKit. Dead devices are devices that have connection problems. Warning: Not responding devices will break HomeKit automations.",
+        "description": "Show dead devices as not responding in HomeKit. Dead devices are devices that have connection problems and in the Fibaro hub selected option to mark such devices. Warning: Not responding device in HomeKit can break automation, it is recommended to place such device in a separate automation.",
         "title": "Mark dead devices",
         "type": "boolean",
         "required": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -113,7 +113,7 @@
         "default": "disabled"
       },
       "addRoomNameToDeviceName": {
-        "description": "If enabled, to each device name will be added the name of the room in which it is located. Default: disabled.",
+        "description": "If enabled, each device name will be prepended with the name of the room in which it is located, e.g.: Bedroom Light.",
         "title": "Add room name to device name.",
         "type": "string",
 	"required": true,      

--- a/config.schema.json
+++ b/config.schema.json
@@ -113,15 +113,21 @@
         "default": "disabled"
       },
       "addRoomNameToDeviceName": {
-        "description": "If enabled, each device name will be prepended with the name of the room in which it is located, e.g.: Bedroom Light.",
+        "description": "If enabled, to each device name will be added the name of the room in which it is located.",
         "title": "Add room name to device name.",
         "type": "string",
 	"required": true,      
         "oneOf": [
           {
-            "title": "Enabled",
+            "title": "After device name",
             "enum": [
               "enabled"
+            ]
+          },
+	  {
+            "title": "Before device name",
+            "enum": [
+              "enabledBefore"
             ]
           },
           {

--- a/config.schema.json
+++ b/config.schema.json
@@ -113,7 +113,7 @@
         "default": "disabled"
       },
       "addRoomNameToDeviceName": {
-        "description": "If enabled, to each device name will be added the name of the room in which it is located.",
+        "description": "If enabled, to each device name will be added the name of the room in which it is located. Warning: changing this may cause that some of your devices will be removed and add as new.",
         "title": "Add room name to device name.",
         "type": "string",
 	"required": true,      

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -222,8 +222,6 @@ export class FibaroHC implements DynamicPlatformPlugin {
           const room = this.getRoomNameById(s.roomID);
           if (room !== undefined && room !== '') {
             s.name = room + ' ' + s.name;
-          } else {
-            s.name = s.name;
           }
         }
         this.addAccessory(s);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -217,6 +217,14 @@ export class FibaroHC implements DynamicPlatformPlugin {
           } else {
             s.name = s.name + ' - ' + 'no-room';
           }
+        } else if (this.config.addRoomNameToDeviceName === 'enabledBefore' && this.rooms) {
+          // patch device name with the room name
+          const room = this.getRoomNameById(s.roomID);
+          if (room !== undefined && room !== '') {
+            s.name = room + ' ' + s.name;
+          } else {
+            s.name = s.name;
+          }
         }
         this.addAccessory(s);
       }


### PR DESCRIPTION
Option to add room name before device name and without '-' . This is because if you add eg. 'Bedroom Light' to room 'Bedroom', Apple will automaticaly remove room name and display this simple as 'Light'.