### PR TITLE
Fix multilevel sensor regressions: deviceRole comparison and airQualitySensorPm25 dispatch

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -98,6 +98,7 @@ export const MANUAL_DEVICE_TYPES = {
   MOTION: 'motion',
   LEAK: 'leak',
   SMOKE: 'smoke',
+  AIR_QUALITY_SENSOR_PM2_5: 'airQualitySensorPm25',
   OUTLET: 'outlet',
 } as const;
 

--- a/src/deviceAuto.ts
+++ b/src/deviceAuto.ts
@@ -229,9 +229,8 @@ export class DeviceConfigurations {
   private static multilevelSensor(Service, Characteristic, device, config, log) {
     const properties = device.properties || {};
     const { deviceRole } = properties;
-    const role = typeof deviceRole === 'string' ? parseInt(deviceRole, 10) : deviceRole;
 
-    switch (role) {
+    switch (deviceRole) {
       case constants.DEVICE_ROLE_TEMPERATURE_SENSOR:
         return [{
           service: Service.TemperatureSensor,

--- a/src/deviceAuto.ts
+++ b/src/deviceAuto.ts
@@ -280,17 +280,16 @@ export class DeviceConfigurations {
   private static doorbellContactSensor(Service, Characteristic, device, config) {
     const properties = device.properties || {};
     const { deviceRole } = properties;
-    const role = typeof deviceRole === 'string' ? parseInt(deviceRole, 10) : deviceRole;
 
     switch (true) {
-      case role === constants.DEVICE_ROLE_MOTION_SENSOR || properties.deviceRole === 'MotionSensor':
+      case deviceRole === constants.DEVICE_ROLE_MOTION_SENSOR:
         return [{
           service: Service.MotionSensor,
           characteristics: [Characteristic.MotionDetected],
           subtype: device.id + '----',
         }];
 
-      case role === constants.DEVICE_ROLE_PRESENCE_SENSOR:
+      case deviceRole === constants.DEVICE_ROLE_PRESENCE_SENSOR:
         return [{
           service: Service.OccupancySensor,
           characteristics: [Characteristic.OccupancyDetected],

--- a/src/deviceManual.ts
+++ b/src/deviceManual.ts
@@ -1,7 +1,7 @@
 // manualDeviceConfigurations.ts
 
 // Configuration for manual device setup
-import { MANUAL_DEVICE_TYPES } from './constants';
+import { MANUAL_DEVICE_TYPES, SUBTYPE_PM2_5 } from './constants';
 
 type ManualConfigFunction = (Service, Characteristic, device) => {
   service;
@@ -131,6 +131,15 @@ export class ManualDeviceConfigurations {
       service: Service.SmokeSensor,
       characteristics: [Characteristic.SmokeDetected],
       subtype: device.id + '----',
+    }];
+  }
+
+  @ManualType(MANUAL_DEVICE_TYPES.AIR_QUALITY_SENSOR_PM2_5)
+  static configureAirQualitySensorPm25(Service, Characteristic, device) {
+    return [{
+      service: Service.AirQualitySensor,
+      characteristics: [Characteristic.AirQuality, Characteristic.PM2_5Density],
+      subtype: device.id + '--' + SUBTYPE_PM2_5,
     }];
   }
 


### PR DESCRIPTION
## Summary
Two regression fixes for multilevel sensor handling:

- **airQualitySensorPm25 manual config**: dispatch lost in the 9f9c9d6 refactor — the `displayAs` option remained in config.schema.json but silently produced a Switch.
- **deviceRole comparison**: broken since d605877 (Oct 2024) — see commit message for details. Temperature/humidity/light multilevel sensors were silently falling through to "Unsupported device role".

## Testing
Verified on HC3 with an IKEA VINDSTYRKA (Zigbee): PM2.5 channel with
`displayAs: airQualitySensorPm25` now appears as an Air Quality Sensor
in the Home app with correct AQI level and density value.