### PR TITLE
Add Air Quality Sensor VOC index manual configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Configure the plugin through the settings UI or directly in the JSON editor.
           "displayAs": "switch",
         },
         {
+          "id": 69,
+          "displayAs": "airQualitySensorVocIndex"
+        },
+        {
           "id": 58,
           "displayAs": "exclude",
         }
@@ -107,7 +111,9 @@ Configure the plugin through the settings UI or directly in the JSON editor.
 
 #### Individual for each device
 + `id` : Device ID (like: 42).
-+ `displayAS` : Display as: switch, dimmer, etc. or exclude device.
++ `displayAS` : Display as: switch, dimmer, air quality sensor, etc. or exclude device.
+  + `airQualitySensorPm25` : Air Quality Sensor reading PM2.5 density (µg/m³).
+  + `airQualitySensorVocIndex` : Air Quality Sensor reading Sensirion VOC Index (relative index, not µg/m³ — e.g. IKEA VINDSTYRKA).
 
 </details>
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -270,6 +270,12 @@
                   ]
                 },
                 {
+                  "title": "Air Quality Sensor - VOC (Sensirion VOC Index)",
+                  "enum": [
+                    "airQualitySensorVocIndex"
+                  ]
+                },
+                {
                   "title": "Outlet",
                   "enum": [
                     "outlet"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -77,6 +77,7 @@ export const SUBTYPE_HEATING_ZONE = 'HZ';
 export const SUBTYPE_RADIATOR_THERMOSTATIC_VALVE = 'RV';
 export const SUBTYPE_OPEN_CLOSE_ONLY = 'OPENCLOSEONLY';
 export const SUBTYPE_PM2_5 = 'PM2_5';
+export const SUBTYPE_VOC_INDEX = 'VOC_INDEX';
 export const SUBTYPE_REMOTE_CONTROLLER_CENTRAL_SCENE = 'CS';
 export const SUBTYPE_REMOTE_CONTROLLER_SCENE_ACTIVATION = 'SA';
 
@@ -99,6 +100,7 @@ export const MANUAL_DEVICE_TYPES = {
   LEAK: 'leak',
   SMOKE: 'smoke',
   AIR_QUALITY_SENSOR_PM2_5: 'airQualitySensorPm25',
+  AIR_QUALITY_SENSOR_VOC_INDEX: 'airQualitySensorVocIndex',
   OUTLET: 'outlet',
 } as const;
 
@@ -145,5 +147,6 @@ export enum Characteristics {
   CurrentRelativeHumidity = 'CurrentRelativeHumidity',
   CurrentAmbientLightLevel = 'CurrentAmbientLightLevel',
   PM2_5Density = 'PM2_5Density',
+  VOCDensity = 'VOCDensity',
   HoldPosition = 'HoldPosition'
 }

--- a/src/deviceManual.ts
+++ b/src/deviceManual.ts
@@ -1,7 +1,7 @@
 // manualDeviceConfigurations.ts
 
 // Configuration for manual device setup
-import { MANUAL_DEVICE_TYPES, SUBTYPE_PM2_5 } from './constants';
+import { MANUAL_DEVICE_TYPES, SUBTYPE_PM2_5, SUBTYPE_VOC_INDEX } from './constants';
 
 type ManualConfigFunction = (Service, Characteristic, device) => {
   service;
@@ -140,6 +140,15 @@ export class ManualDeviceConfigurations {
       service: Service.AirQualitySensor,
       characteristics: [Characteristic.AirQuality, Characteristic.PM2_5Density],
       subtype: device.id + '--' + SUBTYPE_PM2_5,
+    }];
+  }
+
+  @ManualType(MANUAL_DEVICE_TYPES.AIR_QUALITY_SENSOR_VOC_INDEX)
+  static configureAirQualitySensorVocIndex(Service, Characteristic, device) {
+    return [{
+      service: Service.AirQualitySensor,
+      characteristics: [Characteristic.AirQuality, Characteristic.VOCDensity],
+      subtype: device.id + '--' + SUBTYPE_VOC_INDEX,
     }];
   }
 

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -211,6 +211,7 @@ export class FibaroAccessory {
     service.isRadiatorThermostaticValve = IDs.length >= 3 && IDs[2] === constants.SUBTYPE_RADIATOR_THERMOSTATIC_VALVE;
     service.isOpenCloseOnly = IDs.length >= 3 && IDs[2] === constants.SUBTYPE_OPEN_CLOSE_ONLY;
     service.isPM2_5Sensor = IDs.length >= 3 && IDs[2] === constants.SUBTYPE_PM2_5;
+    service.isVOCIndexSensor = IDs.length >= 3 && IDs[2] === constants.SUBTYPE_VOC_INDEX;
     service.isRemoteControllerCentralScene = IDs.length >= 5 && IDs[3] === constants.SUBTYPE_REMOTE_CONTROLLER_CENTRAL_SCENE;
     service.isRemoteControllerSceneActivation = IDs.length >= 5 && IDs[3] === constants.SUBTYPE_REMOTE_CONTROLLER_SCENE_ACTIVATION;
     service.remoteButtonNumber = IDs.length >= 5 ? parseInt(IDs[4]) : -1;

--- a/src/getFunctions.ts
+++ b/src/getFunctions.ts
@@ -517,13 +517,32 @@ export class GetFunctions {
       } else {
         characteristic.updateValue(this.platform.Characteristic.AirQuality.POOR);
       }
+    } else if (_service.isVOCIndexSensor) {
+      // Sensirion VOC Index: relative to the sensor's own 24 h baseline (100),
+      // on a logarithmic scale from 1 to 500. Not a health standard: bands are a
+      // pragmatic mapping anchored on Sensirion's documented values - baseline 100,
+      // air purifier trigger example 150, and algorithm gating threshold 230.
+      // EXCELLENT is intentionally not used, as a relative index cannot certify
+      // absolute air quality.
+      // https://sensirion.com/media/documents/02232963/6294E043/Info_Note_VOC_Index.pdf
+      if (v <= 150) {
+        characteristic.updateValue(this.platform.Characteristic.AirQuality.GOOD);
+      } else if (v <= 230) {
+        characteristic.updateValue(this.platform.Characteristic.AirQuality.FAIR);
+      } else if (v <= 350) {
+        characteristic.updateValue(this.platform.Characteristic.AirQuality.INFERIOR);
+      } else {
+        characteristic.updateValue(this.platform.Characteristic.AirQuality.POOR);
+      }
     }
   }
 
   @characteristicGetter(
     Characteristics.CurrentRelativeHumidity,
     Characteristics.CurrentAmbientLightLevel,
-    Characteristics.PM2_5Density)
+    Characteristics.PM2_5Density,
+    Characteristics.VOCDensity,
+  )
   getFloat(characteristic, _service, _IDs, properties) {
     const value = properties.value;
     if (value !== undefined && !isNaN(value)) {


### PR DESCRIPTION
## Summary

Adds an `airQualitySensorVocIndex` manual config (`displayAs`) option for
sensors reporting Sensirion's VOC Index — e.g. IKEA VINDSTYRKA and other
SEN5x-based devices paired to HC3 via Zigbee. Follows the exact pattern of
the `airQualitySensorPm25` config restored in #958:

- new `SUBTYPE_VOC_INDEX` + `MANUAL_DEVICE_TYPES` entry (`constants.ts`)
- `@ManualType` handler exposing `AirQualitySensor` with `AirQuality` +
  `VOCDensity` (`deviceManual.ts`)
- `isVOCIndexSensor` service flag (`fibaroAccessory.ts`)
- `AirQuality` band mapping and `VOCDensity` via the existing `getFloat`
  (`getFunctions.ts`)
- schema entry (`config.schema.json`)

## Design notes

The VOC Index is a relative, dimensionless value (1–500, logarithmic,
100 = the sensor's own 24 h baseline), not an absolute concentration —
so it is exposed through `VOCDensity` as-is. The `AirQuality` bands are a
pragmatic mapping anchored on Sensirion's documented values (baseline 100,
purifier trigger example 150, gating threshold 230) rather than a health
standard; rationale and source are documented next to the mapping.
`EXCELLENT` is intentionally not used, as a relative index cannot certify
absolute air quality.

The type is named `VocIndex` (not `Voc`) so a separate type for sensors
reporting true VOC density in µg/m³ can be added later without a breaking
rename.

## Testing

Verified on HC3 with an IKEA VINDSTYRKA tVOC channel and
`displayAs: airQualitySensorVocIndex`: the accessory appears as an Air
Quality Sensor in the Home app, the index value updates through polling.