### PR TITLE
Fix polling updates silently skipped for services with subtype flags

### DIFF
--- a/src/pollerupdate.ts
+++ b/src/pollerupdate.ts
@@ -153,7 +153,7 @@ export class Poller {
             change.value = (change.value - 32) * 5 / 9;
           }
 
-          if (service.remoteButtonNumber) {
+          if (service.remoteButtonNumber > 0) {
             if (characteristic.constructor !== this.platform.Characteristic.ProgrammableSwitchEvent) {
               return;
             }


### PR DESCRIPTION
## Summary

Polling updates never fire for any service whose subtype carries a flag
segment (`<id>--FLAG`): door locks, scenes, radiator thermostatic
valves, climate/heating zones, and the air quality sensors from #958.
These accessories only refresh on explicit HomeKit reads — e.g.
reopening the accessory in the Home app — so state changes made outside
HomeKit (physical lock operation, Fibaro scenes/automations) don't show
up while the accessory is on screen.

## Root cause

Two commits from the remote controller / Fibaro Button work in Oct 2024
interact:

- b5a461b assigns `-1` as the `remoteButtonNumber` sentinel for any
  subtype with fewer than five segments
- 61d4483 gates `manageValue` on `if (service.remoteButtonNumber)`

`-1` is truthy, so every flagged-subtype service is treated as a remote
button, and any characteristic that isn't a `ProgrammableSwitchEvent`
hits the early `return` — the update is dropped silently. Plain
`<id>----` subtypes survive only by accident: they parse to `NaN`,
which is falsy.

## Fix

Gate on `remoteButtonNumber > 0` instead. Button numbers are 1-based,
so real remote buttons still match, and both sentinels (`-1` and `NaN`)
are excluded. One line in `pollerupdate.ts`.

## Impact

Shipped in every release since 3.1.0 (Oct 2024). The bug is easy to
miss in practice — opening the accessory in the Home app triggers an
explicit read that masks it — which likely explains the absence of user
reports, but any flagged-subtype accessory silently stops live-updating
while the app is open.

## Testing

Found while testing the pending air-quality/hvac work on real hardware
(HC3): with the fix, flagged-subtype accessories resume live polling
updates (verified via value-change logs and the Home app updating in
real time); plain-subtype accessories behave as before.