### PR TITLE
Prefix hvac mode switch labels and add contributor notes

### DIFF
--- a/docs/home-app-notes.md
+++ b/docs/home-app-notes.md
@@ -1,0 +1,102 @@
+# Home app behaviour
+
+Rendering behaviour of Apple's Home app, none of it documented by Apple, found by
+testing on real accessories. Recorded because several of these took a deploy,
+a cache removal and a restart each to establish — and because the negative
+results are invisible in the code.
+
+Verified on iOS 26 with an accessory exposing a Thermostat, a Fanv2 and up to
+three Switch services.
+
+## Service labels
+
+In an accessory's detail view, the labels next to the extra controls come from
+`ConfiguredName`. Without it every control shows the accessory's name, even when
+the service has a distinct `Name`.
+
+A single extra service is rendered without a label at all — labels only appear
+once there are two or more.
+
+`ConfiguredName` is writable, so it should be seeded only when empty; otherwise a
+rename done in the Home app is overwritten on every restart.
+
+## Where a control shows up
+
+A characteristic on the main service and a separate service are rendered at
+different depths. `RotationSpeed` added to the thermostat ends up behind the
+settings gear, while the same characteristic on its own `Fanv2` service appears
+directly in the detail view. Moving a control onto its own service is the only
+way to surface it.
+
+## Rotation speed steps
+
+`minStep` must divide `maxValue`. With `minStep: 33.34` and a maximum of 100 the
+grid runs 0 / 33.34 / 66.68 / 100.02, the last position exceeds the maximum, and
+the top speed is silently clamped to the one below it. `33.33` works.
+
+## Multiple writes per interaction
+
+One user interaction can produce several writes. Picking a mode while the
+accessory is off writes `Active` and the target state back to back; raising the
+fan from zero writes `Active` and `RotationSpeed`. Devices behind a serial bridge
+mishandle the resulting overlapping commands, which is why the plugin defers the
+power-on command and debounces fan speed.
+
+HomeKit also sends a write when the value is unchanged, so selecting a mode the
+accessory already reports still reaches the device. That is what makes it
+possible to leave a mode the plugin can only approximate.
+
+## What cannot be influenced
+
+- An accessory with several services is summarised on its tile as "N on, M off"
+  rather than by its main service. Neither `setPrimaryService`,
+  `addLinkedService` nor the accessory category changes that. `setPrimaryService`
+  additionally stopped the service labels from being rendered.
+- Adding `TargetFanState` to a `Fanv2` service produced no auto/manual control,
+  with or without `CurrentFanState` alongside it.
+- With `HeaterCooler`, AUTO renders as a two-handle band dial and needs a
+  `HeatingThresholdTemperature` or the dial comes up empty. Making that
+  characteristic read-only does not stop the Home app from letting the handle be
+  dragged — it simply snaps back.
+- Reporting the real operating state through `CurrentHeatingCoolingState` means
+  the Home app treats the tile as off while a device idles, so tapping the tile no
+  longer toggles power.
+
+## Telling a plugin problem from a rendering one
+
+When something doesn't appear in the Home app, check what the accessory actually
+publishes before changing code. The Homebridge UI shows an accessory's services
+and characteristic values, including properties such as step and range, and it
+reads them from the running HAP server rather than from iOS. A third-party
+HomeKit client works too.
+
+If the values there are right and the Home app still disagrees, it is a
+rendering or caching issue, not a plugin bug. Several findings above were
+initially misdiagnosed the other way around.
+
+## Caching
+
+iOS caches characteristic properties and service labels. A changed step, range or
+label may not appear until the accessory is removed from the Homebridge cache
+(Homebridge UI → Remove Single Cached Accessory) and recreated. Verify against
+the Homebridge UI or a third-party app first to tell a plugin bug from a stale
+cache.
+
+## Why the hvac accessories look the way they do
+
+Apple's `HeaterCooler` service looks like the obvious fit for an air
+conditioner, and it was tried first. It was abandoned for three reasons, all of
+them documented above: its AUTO state needs a heating threshold that cannot be
+made read-only in a way the Home app respects; its `RotationSpeed` ends up behind
+the settings gear rather than in the detail view; and splitting power (`Active`)
+from mode into two characteristics is what makes iOS send two writes for one
+interaction, which serial-bridged devices mishandle.
+
+A `Thermostat` avoids all three: power is a mode, so there is one write, and the
+temperature dial is the main control. Fan speed then moves to its own `Fanv2`
+service to be reachable, and the modes HomeKit has no vocabulary for become
+switches. Tapping the tile to toggle power works with either service, so nothing
+was lost there.
+
+The cost is a grouped tile summarised as "N on, M off", which nothing in HAP
+appears to change.

--- a/docs/home-center-notes.md
+++ b/docs/home-center-notes.md
@@ -1,0 +1,83 @@
+# Home Center behaviour
+
+Behaviour of the Home Center that isn't in the API documentation, found while
+building the hvac support against a real HC3. Kept here because the plugin's
+design in several places only makes sense once you know it.
+
+## Change events
+
+`refreshStates` coalesces properties updated in quick succession into a single
+change. A QuickApp that sets mode, setpoint and fan mode one after another
+produces one change carrying all three, so dispatch has to handle each property
+independently — an either/or chain would apply only the first.
+
+Numeric properties arrive as strings in a change (`"18.00"`), not as numbers.
+
+## Actions
+
+Booleans in action arguments sent over REST are coerced to `0` / `1`. The same
+action invoked from the Home Center's own UI keeps them as booleans, so a
+QuickApp handler should accept both forms.
+
+`setThermostatFanMode` takes a second argument, the fan-off flag, which only
+applies to devices reporting `supportsThermostatFanOff`. The plugin sends the
+speed alone rather than passing `false`, which the REST layer would coerce to `0`
+anyway.
+
+## Thermostat vocabulary
+
+Thermostat mode and fan mode values are the Z-Wave command class names in
+PascalCase: `Off`, `Cool`, `Heat`, `Auto`, `Dry`, `Fan`, `FullPower` for modes;
+`Low`, `Medium`, `High`, `AutoLow`, `AutoMedium`, `AutoHigh` for fan modes.
+
+The API accepts arbitrary strings, but the Home Center UI silently ignores values
+it doesn't recognise — a device reporting localised mode names renders no mode
+buttons at all. Recognised values are translated for display, so `FullPower`
+shows up as "Max".
+
+## Capability reporting
+
+Devices report what they support: `supportedThermostatModes`,
+`supportedThermostatFanModes`, and `heating`/`coolingThermostatSetpointCapabilities`
+`Min`/`Max`/`Step`. Deriving services and characteristic properties from those
+reports keeps the plugin working on devices that expose less, which is why the
+hvac support creates a fan service and mode switches only for what a device
+actually lists.
+
+Fan-only off exists in the model as a capability/state pair
+(`supportsThermostatFanOff`, `thermostatFanOff`), and the state does appear in
+`refreshStates`. It isn't wired up: `Active` would have to be the OR of two
+properties that arrive in separate changes, which one subscription per
+characteristic cannot express directly.
+
+## Checking things against a Home Center
+
+Most of the above was established with these four calls. Substitute the host and
+a Basic auth token.
+
+Read a device's full state, including which interfaces and actions it carries:
+
+    curl -sk "http://<hc3>/api/devices/49" -H 'Authorization: Basic <token>' | jq
+
+List the device type hierarchy, useful for finding which type a child device
+should use:
+
+    curl -sk "http://<hc3>/api/devices/hierarchy" -H 'Authorization: Basic <token>' | jq
+
+Watch change events the way the plugin's poller sees them. Take a cursor first,
+then perform the action, then read everything since that cursor:
+
+    LAST=$(curl -sk "http://<hc3>/api/refreshStates?last=0" -H 'Authorization: Basic <token>' | jq '.last')
+    # perform the action in the Home Center UI or the Home app
+    curl -sk "http://<hc3>/api/refreshStates?last=$LAST" -H 'Authorization: Basic <token>' \
+      | jq '.changes[] | select(.id==49)'
+
+This is how coalescing was found: a single change object carrying `thermostatMode`
+and `coolingThermostatSetpoint` together.
+
+Invoke a device action directly, which is what the plugin does and a good way to
+tell a plugin problem from a device one:
+
+    curl -sk -X POST "http://<hc3>/api/devices/49/action/setThermostatFanMode" \
+      -H 'Content-Type: application/json' -H 'Authorization: Basic <token>' \
+      -d '{"args":["Medium"]}'

--- a/src/fibaroAccessory.ts
+++ b/src/fibaroAccessory.ts
@@ -114,7 +114,7 @@ export class FibaroAccessory {
     } else if (subtype.split('-')[2] === constants.SUBTYPE_HVAC_FAN_SPEED) {
       return this.device.name + ' Fan speed';
     } else if (constants.HVAC_MODE_SWITCHES[subtype.split('-')[2]]) {
-      return this.device.name + ' ' + constants.HVAC_MODE_SWITCHES[subtype.split('-')[2]].label;
+      return this.device.name + ' Mode ' + constants.HVAC_MODE_SWITCHES[subtype.split('-')[2]].label;
     } else {
       return this.device.name;
     }
@@ -130,7 +130,9 @@ export class FibaroAccessory {
     } else if (subtype.split('-')[2] === constants.SUBTYPE_HVAC_FAN_SPEED) {
       return 'Fan speed';
     }
-    return constants.HVAC_MODE_SWITCHES[subtype.split('-')[2]]?.label ?? null;
+    return constants.HVAC_MODE_SWITCHES[subtype.split('-')[2]]
+      ? 'Mode ' + constants.HVAC_MODE_SWITCHES[subtype.split('-')[2]].label
+      : null;
   }
 
   bindCharacterstics(service, characteristics) {


### PR DESCRIPTION
## Mode switch labels

The Home app sorts the controls in an accessory's detail view alphabetically, so
the hvac mode switches ended up scattered around the fan service — `Dry`, `Fan`,
`Fan speed`, `Max` — with the `Fan` mode switch sitting right next to the
unrelated fan speed control. Prefixing them (`Mode Dry`, `Mode Fan`, `Mode Max`)
keeps the three together and apart from the fan.

Existing accessories keep their current labels, since `ConfiguredName` is only
seeded when empty.

## Contributor notes

Two documents recording things that aren't in the code and that took hardware
experiments to establish: how the Home Center behaves (change events being
coalesced, argument coercion, the thermostat vocabulary its UI recognises) and
how the Home app renders services (where a control ends up depending on how it is
exposed, when service labels appear, what it ignores, and what caching hides).
Both end with the calls or steps used to establish the findings, so they can be
re-checked when a firmware or iOS version changes.

They also record the negative results — what was tried and did not work — which
otherwise leave no trace in the code. The `HeaterCooler` section explains why the
hvac accessories are shaped the way they are, which should save the next person
that detour.

Happy to move or rename either file if you'd rather they lived somewhere else.